### PR TITLE
Fix to_string for SlackConversationType

### DIFF
--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -117,8 +117,8 @@ impl ToString for SlackConversationType {
         match self {
             SlackConversationType::IM => "im".into(),
             SlackConversationType::MPIM => "mpim".into(),
-            SlackConversationType::PRIVATE => "private".into(),
-            SlackConversationType::PUBLIC => "public".into(),
+            SlackConversationType::PRIVATE => "private_channel".into(),
+            SlackConversationType::PUBLIC => "public_channel".into(),
         }
     }
 }


### PR DESCRIPTION
SlackConversationType::PUBLIC and SlackConversationType::PRIVATE should convert to "public_channel" and "private_channel", instead of just "public" and "private".
See https://api.slack.com/methods/conversations.list .