### PR TITLE
Update Slack's special formatting characters

### DIFF
--- a/src/models/src/blocks/datetime.rs
+++ b/src/models/src/blocks/datetime.rs
@@ -28,7 +28,7 @@ impl ToString for SlackDateTimeFormats {
     }
 }
 
-pub fn fmt_slack_date<TZ: TimeZone>(
+pub fn fmt_slack_date1<TZ: TimeZone>(
     date: DateTime<TZ>,
     token_string: &str,
     link: Option<&String>,
@@ -37,11 +37,11 @@ where
     <TZ as chrono::offset::TimeZone>::Offset: std::fmt::Display,
 {
     let link_part = link
-        .map(|value| format!("^${}", value))
+        .map(|value| format!("^{}", value))
         .unwrap_or_else(|| "".into());
     let fallback = date.to_rfc2822();
     format!(
-        "<!date^${timestamp}^${token_string}${link_part}|${fallback}>",
+        "<!date^{timestamp}^{token_string}{link_part}|{fallback}>",
         timestamp = date.timestamp(),
         token_string = token_string,
         link_part = link_part,

--- a/src/models/src/blocks/datetime.rs
+++ b/src/models/src/blocks/datetime.rs
@@ -28,7 +28,7 @@ impl ToString for SlackDateTimeFormats {
     }
 }
 
-pub fn fmt_slack_date1<TZ: TimeZone>(
+pub fn fmt_slack_date<TZ: TimeZone>(
     date: DateTime<TZ>,
     token_string: &str,
     link: Option<&String>,

--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -63,7 +63,7 @@ pub struct SlackUserId(pub String);
 
 impl SlackTextFormat for SlackUserId {
     fn to_slack_format(&self) -> String {
-        format!("<@${}", self.value())
+        format!("<@{}>", self.value())
     }
 }
 

--- a/src/models/src/events/command.rs
+++ b/src/models/src/events/command.rs
@@ -19,6 +19,7 @@ pub struct SlackCommandEvent {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackCommandEventResponse {
+    #[serde(flatten)]
     pub content: SlackMessageContent,
     pub response_type: Option<SlackMessageResponseType>,
 }


### PR DESCRIPTION
- Updated Date formatting and User Mentions according to https://api.slack.com/reference/surfaces/formatting
- Updated Commands response formatting according to https://api.slack.com/interactivity/slash-commands
