### PR TITLE
Fix priority type for SlackChannelInfo

### DIFF
--- a/src/models/src/common/channel.rs
+++ b/src/models/src/common/channel.rs
@@ -18,7 +18,7 @@ pub struct SlackChannelInfo {
     pub topic: Option<SlackChannelTopicInfo>,
     pub purpose: Option<SlackChannelPurposeInfo>,
     pub previous_names: Option<Vec<String>>,
-    pub priority: Option<u64>,
+    pub priority: Option<f64>,
     pub num_members: Option<u64>,
     pub locale: Option<SlackLocale>,
     #[serde(flatten)]


### PR DESCRIPTION
SlackChannelInfo::priority should f64, instead of u64.
See https://api.slack.com/methods/conversations.info .