### PR TITLE
Fix block kit issues for Input block.

### DIFF
--- a/src/models/src/blocks/kit.rs
+++ b/src/models/src/blocks/kit.rs
@@ -123,6 +123,7 @@ pub struct SlackInputBlock {
     pub element: SlackInputBlockElement,
     pub hint: Option<SlackBlockPlainText>,
     pub optional: Option<bool>,
+    pub dispatch_action: Option<bool>,
 }
 
 impl From<SlackInputBlock> for SlackBlock {

--- a/src/models/src/blocks/kit.rs
+++ b/src/models/src/blocks/kit.rs
@@ -119,7 +119,7 @@ impl From<SlackContextBlock> for SlackBlock {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackInputBlock {
     pub block_id: Option<SlackBlockId>,
-    pub label: SlackBlockPlainText,
+    pub label: SlackBlockText,
     pub element: SlackInputBlockElement,
     pub hint: Option<SlackBlockPlainText>,
     pub optional: Option<bool>,


### PR DESCRIPTION
- Label needs to have the type included.
- Input block supports immediate dispatch.