### PR TITLE
Fix bug in range of supported timezones in `SlackUser`

### DIFF
--- a/src/models/src/common/user.rs
+++ b/src/models/src/common/user.rs
@@ -16,7 +16,7 @@ pub struct SlackUser {
     pub flags: SlackUserFlags,
     pub tz: Option<String>,
     pub tz_label: Option<String>,
-    pub tz_offset: Option<i16>,
+    pub tz_offset: Option<i32>,
     pub updated: Option<SlackDateTime>,
     pub deleted: Option<bool>,
     pub color: Option<SlackColor>,


### PR DESCRIPTION
This changes the type of `tz_offset` from `i16` to `i32`.

 [`tz_offset` is the number of seconds to offset UTC time by](https://api.slack.com/types/user).
If the offset is greater than 9 hours, it is outside i16 range when represented in seconds.
I found this subtle bug because one of my coworkers appears to be in Honolulu, prompting the deserialization to error.