### PR TITLE
Add support for using any hyper connector

### DIFF
--- a/src/hyper/Cargo.toml
+++ b/src/hyper/Cargo.toml
@@ -28,6 +28,7 @@ rsb_derive = "0.5"
 hyper = { version ="0.14", features = ["full"] }
 tokio = { version = "1.14", features = ["full"] }
 tokio-stream = { version = "0.1.8" }
+hyper-proxy = "0.9"
 hyper-rustls = "0.22"
 url = "2.2"
 mime = "0.3"

--- a/src/hyper/Cargo.toml
+++ b/src/hyper/Cargo.toml
@@ -28,7 +28,6 @@ rsb_derive = "0.5"
 hyper = { version ="0.14", features = ["full"] }
 tokio = { version = "1.14", features = ["full"] }
 tokio-stream = { version = "0.1.8" }
-hyper-proxy = "0.9"
 hyper-rustls = "0.22"
 url = "2.2"
 mime = "0.3"

--- a/src/hyper/src/lib.rs
+++ b/src/hyper/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub use crate::connector::SlackClientHyperConnector;
 pub use crate::connector::SlackClientHyperHttpsConnector;
-pub use crate::connector::SlackClientHyperProxyHttpsConnector;
 use slack_morphism::SlackClient;
 
 pub mod connector;
@@ -11,7 +10,6 @@ pub mod scroller_ext;
 mod socket_mode;
 
 pub type SlackHyperClient = SlackClient<SlackClientHyperHttpsConnector>;
-pub type SlackHyperProxyClient = SlackClient<SlackClientHyperProxyHttpsConnector>;
 
 pub use listener::chain_service_routes_fn;
 pub use listener::SlackClientEventsHyperListener;

--- a/src/hyper/src/lib.rs
+++ b/src/hyper/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::new_without_default)]
 
 pub use crate::connector::SlackClientHyperConnector;
+pub use crate::connector::SlackClientHyperHttpsConnector;
+pub use crate::connector::SlackClientHyperProxyHttpsConnector;
 use slack_morphism::SlackClient;
 
 pub mod connector;
@@ -8,7 +10,8 @@ pub mod listener;
 pub mod scroller_ext;
 mod socket_mode;
 
-pub type SlackHyperClient = SlackClient<SlackClientHyperConnector>;
+pub type SlackHyperClient = SlackClient<SlackClientHyperHttpsConnector>;
+pub type SlackHyperProxyClient = SlackClient<SlackClientHyperProxyHttpsConnector>;
 
 pub use listener::chain_service_routes_fn;
 pub use listener::SlackClientEventsHyperListener;

--- a/src/hyper/src/listener/mod.rs
+++ b/src/hyper/src/listener/mod.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 
 use futures::future::{BoxFuture, FutureExt};
 use hyper::{Body, Request, Response};
+use hyper::client::connect::Connect;
 
 pub use command_events::*;
 pub use interaction_events::*;
@@ -18,13 +19,13 @@ mod interaction_events;
 mod oauth;
 mod push_events;
 
-pub struct SlackClientEventsHyperListener {
-    pub environment: Arc<SlackClientEventsListenerEnvironment<SlackClientHyperConnector>>,
+pub struct SlackClientEventsHyperListener<H: 'static + Send + Sync + Connect + Clone> {
+    pub environment: Arc<SlackClientEventsListenerEnvironment<SlackClientHyperConnector<H>>>,
 }
 
-impl SlackClientEventsHyperListener {
+impl<H: 'static + Send + Sync + Connect + Clone> SlackClientEventsHyperListener<H> {
     pub fn new(
-        environment: Arc<SlackClientEventsListenerEnvironment<SlackClientHyperConnector>>,
+        environment: Arc<SlackClientEventsListenerEnvironment<SlackClientHyperConnector<H>>>,
     ) -> Self {
         Self { environment }
     }

--- a/src/hyper/src/listener/mod.rs
+++ b/src/hyper/src/listener/mod.rs
@@ -3,8 +3,8 @@ use crate::connector::SlackClientHyperConnector;
 use std::future::Future;
 
 use futures::future::{BoxFuture, FutureExt};
-use hyper::{Body, Request, Response};
 use hyper::client::connect::Connect;
+use hyper::{Body, Request, Response};
 
 pub use command_events::*;
 pub use interaction_events::*;

--- a/src/hyper/src/listener/oauth.rs
+++ b/src/hyper/src/listener/oauth.rs
@@ -73,7 +73,9 @@ impl<H: 'static + Send + Sync + Connect + Clone> SlackClientEventsHyperListener<
                             &oauth_resp.authed_user.id
                         );
                         install_service_fn(oauth_resp, client, user_state_storage).await;
-                        SlackClientHyperConnector::<H>::hyper_redirect_to(&config.redirect_installed_url)
+                        SlackClientHyperConnector::<H>::hyper_redirect_to(
+                            &config.redirect_installed_url,
+                        )
                     }
                     Err(err) => {
                         error!("Slack OAuth error: {}", &err);
@@ -110,7 +112,9 @@ impl<H: 'static + Send + Sync + Connect + Clone> SlackClientEventsHyperListener<
                     client,
                     user_state_storage,
                 );
-                SlackClientHyperConnector::<H>::hyper_redirect_to(&config.redirect_error_redirect_url)
+                SlackClientHyperConnector::<H>::hyper_redirect_to(
+                    &config.redirect_error_redirect_url,
+                )
             }
         }
     }

--- a/src/hyper/src/socket_mode/mod.rs
+++ b/src/hyper/src/socket_mode/mod.rs
@@ -10,6 +10,7 @@ use slack_morphism::clients::{
 use slack_morphism::errors::*;
 use slack_morphism::*;
 use slack_morphism_models::SlackWebSocketsUrl;
+use hyper::client::connect::Connect;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
@@ -412,7 +413,9 @@ impl SlackSocketModeWssClient for SlackTungsteniteWssClient {
     }
 }
 
-impl SlackSocketModeWssClientsFactory<SlackTungsteniteWssClient> for SlackClientHyperConnector {
+impl<H: Send + Sync + Clone + Connect> SlackSocketModeWssClientsFactory<SlackTungsteniteWssClient>
+    for SlackClientHyperConnector<H>
+{
     fn create_wss_client(
         &self,
         wss_url: &SlackWebSocketsUrl,

--- a/src/hyper/src/socket_mode/mod.rs
+++ b/src/hyper/src/socket_mode/mod.rs
@@ -1,6 +1,7 @@
 use crate::SlackClientHyperConnector;
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
+use hyper::client::connect::Connect;
 use log::*;
 use rvstruct::*;
 use slack_morphism::clients::{
@@ -10,7 +11,6 @@ use slack_morphism::clients::{
 use slack_morphism::errors::*;
 use slack_morphism::*;
 use slack_morphism_models::SlackWebSocketsUrl;
-use hyper::client::connect::Connect;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;


### PR DESCRIPTION
This adds support for using any hyper connector; `SlackClientHyperConnector` is made generic over types `H` satisfying trait bounds `'static + Send + Sync + Clone + hyper::client::connect::Connect`.
In particular, I have added support for using an http proxy with new alias `SlackHyperProxyClient`.
Usage would look like this:
```
    let hyper_connector = SlackClientHyperConnector::with_proxy("http://proxy.domain:3333");
```

The type alias `SlackHyperClient` is unchanged and the constructor name is distinct from `new()`, so the changes are non-breaking wherever these have been used.