### PR TITLE
feat: implement From trait for SlackClientHyperConnector from an arbitrary HttpsConnector

### DIFF
--- a/src/hyper/src/connector.rs
+++ b/src/hyper/src/connector.rs
@@ -35,6 +35,14 @@ impl SlackClientHyperConnector<HttpsConnector<HttpConnector>> {
     }
 }
 
+impl From<HttpsConnector<HttpConnector>>
+    for SlackClientHyperConnector<HttpsConnector<HttpConnector>>
+{
+    fn from(https_connector: hyper_rustls::HttpsConnector<HttpConnector>) -> Self {
+        Self::with_connector(https_connector)
+    }
+}
+
 impl<H: 'static + Send + Sync + Clone + connect::Connect> SlackClientHyperConnector<H> {
     pub fn with_connector(connector: H) -> Self {
         Self {


### PR DESCRIPTION
Implement `From<hyper_rustls::HttpsConnector>` for
`SlackClientHyperConnector`. This allows us to use custom SSL
certificate validation for unit tests based on mock servers.