### PR TITLE
Add model and support for Slack's `link_shared` event push callback subtype

### DIFF
--- a/src/models/src/events/push.rs
+++ b/src/models/src/events/push.rs
@@ -130,19 +130,19 @@ pub struct SlackAppUninstalledEvent {}
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackLinkSharedEvent {
-    channel: SlackChannelId,
-    event_ts: SlackTs,
-    is_bot_user_member: bool,
-    links: Vec<SlackLinkObject>,
-    message_ts: SlackTs,
-    source: String,
-    unfurl_id: String,
-    user: SlackUserId,
+    pub channel: SlackChannelId,
+    pub event_ts: SlackTs,
+    pub is_bot_user_member: bool,
+    pub links: Vec<SlackLinkObject>,
+    pub message_ts: SlackTs,
+    pub source: String,
+    pub unfurl_id: String,
+    pub user: SlackUserId,
 }
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackLinkObject {
-    domain: String,
-    url: String,
+    pub domain: String,
+    pub url: String,
 }

--- a/src/models/src/events/push.rs
+++ b/src/models/src/events/push.rs
@@ -47,16 +47,13 @@ pub struct SlackPushEventCallback {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum SlackEventCallbackBody {
-    #[serde(rename = "message")]
     Message(SlackMessageEvent),
-    #[serde(rename = "app_home_opened")]
     AppHomeOpened(SlackAppHomeOpenedEvent),
-    #[serde(rename = "app_mention")]
     AppMention(SlackAppMentionEvent),
-    #[serde(rename = "app_uninstalled")]
     AppUninstalled(SlackAppUninstalledEvent),
+    LinkShared(SlackLinkSharedEvent),
 }
 
 #[skip_serializing_none]
@@ -129,3 +126,23 @@ type SlackMessageEventEdited = SlackMessageEdited;
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackAppUninstalledEvent {}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackLinkSharedEvent {
+    channel: SlackChannelId,
+    event_ts: SlackTs,
+    is_bot_user_member: bool,
+    links: Vec<SlackLinkObject>,
+    message_ts: SlackTs,
+    source: String,
+    unfurl_id: String,
+    user: SlackUserId,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackLinkObject {
+    domain: String,
+    url: String,
+}


### PR DESCRIPTION
Currently used in [this project](https://github.com/noxasaxon/songwhip-bot-rs).

API - https://api.slack.com/events/link_shared

Allows you to receive events when links from up to 5 different domains are shared to _any_ channel/group


Created a `SlackLinkSharedEvent` struct, and updated the `SlackEventCallbackBody` to use serde's rename_all `snake_case` instead of manually writing out the rename attribute for each variant