### PR TITLE
Move to async signal handling

### DIFF
--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -34,7 +34,8 @@ ring = "0.16"
 lazy_static = "1.4"
 http = "0.2"
 async-trait = "0.1.52"
-signal-hook = { version = "0.3.13", features = ["extended-siginfo"]}
+signal-hook = { version = "0.3.13", features = ["extended-siginfo"] }
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["run-for-all", "prepush-hook", "run-cargo-fmt"] }

--- a/src/client/src/socket_mode/listener.rs
+++ b/src/client/src/socket_mode/listener.rs
@@ -2,10 +2,11 @@ use crate::listener::SlackClientEventsListenerEnvironment;
 use crate::socket_mode::clients_manager::*;
 use crate::socket_mode::clients_manager_listener::SlackSocketModeClientsManagerListener;
 use crate::*;
+use futures::stream::StreamExt;
 use log::debug;
 use signal_hook::consts::TERM_SIGNALS;
 use signal_hook::iterator::exfiltrator::WithOrigin;
-use signal_hook::iterator::SignalsInfo;
+use signal_hook_tokio::SignalsInfo;
 use std::sync::Arc;
 
 pub struct SlackClientSocketModeListener<SCHC>
@@ -79,7 +80,7 @@ where
 
         let mut signals = SignalsInfo::<WithOrigin>::new(TERM_SIGNALS).unwrap();
 
-        if let Some(info) = (&mut signals).into_iter().next() {
+        if let Some(info) = signals.next().await {
             debug!("Received a signal: {:?}. Terminating...", info);
         }
 


### PR DESCRIPTION
The way it was before, the signal handling would block a thread,
preventing other tasks on it from getting run time.