### PR TITLE
fix get_permalink response struct

### DIFF
--- a/src/client/src/api/chat.rs
+++ b/src/client/src/api/chat.rs
@@ -190,7 +190,7 @@ pub struct SlackApiChatGetPermalinkRequest {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiChatGetPermalinkResponse {
     pub channel: SlackChannelId,
-    pub message_ts: SlackTs,
+    pub permalink: String,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
👋 hey @abdolence, quick fix for get_permalink. [According to the docs](https://api.slack.com/methods/chat.getPermalink), I think the existing response struct is malformed