### PR TITLE
Add `status_emoji` to `SlackUserProfile`

### DIFF
--- a/src/models/src/common/user.rs
+++ b/src/models/src/common/user.rs
@@ -33,6 +33,7 @@ pub struct SlackUserProfile {
     pub avatar_hash: Option<String>,
     pub status_text: Option<String>,
     pub status_expiration: Option<SlackDateTime>,
+    pub status_emoji: Option<String>,
     pub display_name_normalized: Option<String>,
     pub email: Option<String>,
     #[serde(flatten)]


### PR DESCRIPTION
Added a new field so that custom statuses with emoji can be set.

https://api.slack.com/docs/presence-and-status#user-presence-and-status__custom-status__writing-custom-statuses