### PR TITLE
feat: Add channel field to response of chat.postMessage

### DIFF
--- a/src/client/src/api/chat.rs
+++ b/src/client/src/api/chat.rs
@@ -250,6 +250,7 @@ pub struct SlackApiChatPostMessageRequest {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiChatPostMessageResponse {
+    pub channel: SlackChannelId,
     pub ts: SlackTs,
     pub message: SlackMessage,
 }


### PR DESCRIPTION
After sending a request to chat.postMessage endpoint, `SlackApiChatPostMessageResponse` will be retrieved from the API response. It includes `SlackMessage`, so I expected to get `ChannelId` where the message sent from `SlackMessageOrigin::channel`. However the field is always empty even if the API response contains `channel` field.

Payload of the response looks like:
```json
{
  "ts": "123456789.12345",
  "channel": "C123456789",
  "message": {
    ...
  }
}
```

In this payload, `.message` is mapped to `SlackMessage` and it does not include `.message.channel` in their fields. It was required to use `.channel` instead.

This pull request introduces a new `channel` field on `SlackApiChatPostMessageResponse` to access the field as described above.