### PR TITLE
feat: Fix type of view values in view_submission event

### DIFF
--- a/src/models/src/blocks/kit.rs
+++ b/src/models/src/blocks/kit.rs
@@ -7,7 +7,7 @@ use url::Url;
 use crate::common::*;
 
 #[skip_serializing_none]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, ValueStruct)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize, ValueStruct)]
 pub struct SlackBlockId(pub String);
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/src/models/src/blocks/view.rs
+++ b/src/models/src/blocks/view.rs
@@ -1,5 +1,5 @@
 use crate::blocks::kit::SlackBlock;
-use crate::blocks::{SlackBlockId, SlackBlockPlainTextOnly};
+use crate::blocks::{SlackBlockId, SlackBlockPlainText, SlackBlockPlainTextOnly};
 use crate::common::SlackCallbackId;
 use crate::*;
 use rsb_derive::Builder;
@@ -80,4 +80,27 @@ pub struct SlackViewStateValue {
     #[serde(rename = "type")]
     pub action_type: SlackActionType,
     pub value: Option<String>,
+    pub selected_date: Option<String>,
+    pub selected_time: Option<String>,
+    pub selected_conversation: Option<SlackConversationId>,
+    pub selected_channel: Option<SlackChannelId>,
+    pub selected_user: Option<SlackUserId>,
+    pub selected_option: Option<SlackViewStateValueSelectedOption>,
+    pub selected_conversations: Option<Vec<SlackConversationId>>,
+    pub selected_users: Option<Vec<SlackUserId>>,
+    pub selected_options: Option<Vec<SlackViewStateValueSelectedOption>>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackViewStateValueSelectedOption {
+    pub text: SlackViewStateValueSelectedOptionText,
+    pub value: String,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackViewStateValueSelectedOptionText {
+    pub text: String,
+    pub emoji: Option<bool>,
 }

--- a/src/models/src/blocks/view.rs
+++ b/src/models/src/blocks/view.rs
@@ -94,13 +94,6 @@ pub struct SlackViewStateValue {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackViewStateValueSelectedOption {
-    pub text: SlackViewStateValueSelectedOptionText,
+    pub text: SlackBlockPlainText,
     pub value: String,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
-pub struct SlackViewStateValueSelectedOptionText {
-    pub text: String,
-    pub emoji: Option<bool>,
 }

--- a/src/models/src/blocks/view.rs
+++ b/src/models/src/blocks/view.rs
@@ -1,5 +1,5 @@
 use crate::blocks::kit::SlackBlock;
-use crate::blocks::SlackBlockPlainTextOnly;
+use crate::blocks::{SlackBlockId, SlackBlockPlainTextOnly};
 use crate::common::SlackCallbackId;
 use crate::*;
 use rsb_derive::Builder;
@@ -72,5 +72,13 @@ pub struct SlackStatefulStateParams {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackViewState {
-    pub values: HashMap<String, serde_json::Value>,
+    pub values: HashMap<SlackBlockId, HashMap<SlackActionId, SlackViewStateValue>>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackViewStateValue {
+    #[serde(rename = "type")]
+    pub action_type: SlackActionType,
+    pub value: Option<String>,
 }

--- a/src/models/src/blocks/view.rs
+++ b/src/models/src/blocks/view.rs
@@ -62,7 +62,6 @@ pub struct SlackStatefulStateParams {
     pub team_id: SlackTeamId,
     pub state: Option<SlackViewState>,
     pub hash: String,
-    pub callback_id: Option<SlackCallbackId>,
     pub previous_view_id: Option<SlackViewId>,
     pub root_view_id: Option<SlackViewId>,
     pub app_id: Option<SlackAppId>,

--- a/src/models/src/blocks/view.rs
+++ b/src/models/src/blocks/view.rs
@@ -62,6 +62,7 @@ pub struct SlackStatefulStateParams {
     pub team_id: SlackTeamId,
     pub state: Option<SlackViewState>,
     pub hash: String,
+    pub callback_id: Option<SlackCallbackId>,
     pub previous_view_id: Option<SlackViewId>,
     pub root_view_id: Option<SlackViewId>,
     pub app_id: Option<SlackAppId>,

--- a/src/models/src/events/interaction.rs
+++ b/src/models/src/events/interaction.rs
@@ -117,6 +117,7 @@ pub struct SlackInteractionViewSubmissionEvent {
     pub team: SlackBasicTeamInfo,
     pub user: SlackBasicUserInfo,
     pub view: SlackStatefulView,
+    pub trigger_id: Option<SlackTriggerId>,
 }
 
 #[skip_serializing_none]
@@ -125,4 +126,5 @@ pub struct SlackInteractionViewClosedEvent {
     pub team: SlackBasicTeamInfo,
     pub user: SlackBasicUserInfo,
     pub view: SlackStatefulView,
+    pub trigger_id: Option<SlackTriggerId>,
 }


### PR DESCRIPTION
Currently view values in view_submission events are `serde_json::Value`, which is too loose. To fix the type narrower, this pull request proposes to change the type into `HashMap<SlackBlockId, HashMap<SlackActionId, SlackViewStateValue>>`. This structure is documented at https://api.slack.com/reference/interaction-payloads/views#view_submission .

This PR additionally adds `trigger_id` fields into `SlackInteractionViewSubmissionEvent` and `SlackInteractionViewClosedEvent`, which is not documented but actually exists in the payload.
