### PR TITLE
feat: Add missing support for apps.manifest.* APIs

### DIFF
--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/lib.rs"
 slack-morphism-models = { path = "../models", version = "^0.39.0"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_with = "1.14"
+serde_with = { version = "1.14", features = ["json"] }
 rvstruct = "0.3"
 rsb_derive = "0.5"
 url = "2.2"

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -96,6 +96,22 @@ where
             )
             .await
     }
+
+    ///
+    /// https://api.slack.com/methods/apps.manifest.validate
+    ///
+    pub async fn apps_manifest_validate(
+        &self,
+        req: &SlackApiAppsManifestValidateRequest,
+    ) -> ClientResult<()> {
+        self.http_session_api
+            .http_post(
+                "apps.manifest.validate",
+                req,
+                Some(&SLACK_TIER3_METHOD_CONFIG),
+            )
+            .await
+    }
 }
 
 #[skip_serializing_none]
@@ -169,6 +185,21 @@ pub struct SlackApiAppsManifestUpdateRequest {
 pub struct SlackApiAppsManifestUpdateResponse {
     pub app_id: SlackAppId,
     pub permissions_updated: bool,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiAppsManifestValidateRequest {
+    // HACK: This API requires a "json-encoded" string in a JSON object.
+    //       Using these `as_json_string` and `from_json_string` functions,
+    //       we enforce serde to encode or decode the field from/to JSON.
+    #[serde(
+        serialize_with = "as_json_string",
+        deserialize_with = "from_json_string"
+    )]
+    pub manifest: SlackAppManifest,
+
+    pub app_id: Option<SlackAppId>,
 }
 
 fn as_json_string<T, S>(x: &T, s: S) -> Result<S::Ok, S::Error>

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -5,6 +5,7 @@
 use rsb_derive::Builder;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::skip_serializing_none;
+use url::Url;
 
 use slack_morphism_models::*;
 
@@ -26,6 +27,22 @@ where
         self.http_session_api
             .http_post(
                 "apps.connections.open",
+                req,
+                Some(&SLACK_TIER1_METHOD_CONFIG),
+            )
+            .await
+    }
+
+    ///
+    /// https://api.slack.com/methods/apps.manifest.create
+    ///
+    pub async fn apps_manifest_create(
+        &self,
+        req: &SlackApiAppsManifestCreateRequest,
+    ) -> ClientResult<SlackApiAppsManifestCreateResponse> {
+        self.http_session_api
+            .http_post(
+                "apps.manifest.create",
                 req,
                 Some(&SLACK_TIER1_METHOD_CONFIG),
             )
@@ -73,6 +90,29 @@ pub struct SlackApiAppsConnectionOpenRequest {}
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiAppsConnectionOpenResponse {
     pub url: SlackWebSocketsUrl,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiAppsManifestCreateRequest {
+    pub app_id: SlackAppId,
+
+    // HACK: This API requires a "json-encoded" string in a JSON object.
+    //       Using these `as_json_string` and `from_json_string` functions,
+    //       we enforce serde to encode or decode the field from/to JSON.
+    #[serde(
+        serialize_with = "as_json_string",
+        deserialize_with = "from_json_string"
+    )]
+    pub manifest: SlackAppManifest,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiAppsManifestCreateResponse {
+    pub app_id: SlackAppId,
+    pub credentials: SlackAppCredentials,
+    pub oauth_authorize_url: Url,
 }
 
 #[skip_serializing_none]

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -91,6 +91,10 @@ pub struct SlackApiAppsManifestExportResponse {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiAppsManifestUpdateRequest {
     pub app_id: SlackAppId,
+
+    // HACK: This API requires a "json-encoded" string in a JSON object.
+    //       Using these `as_json_string` and `from_json_string` functions,
+    //       we enforce serde to encode or decode the field from/to JSON.
     #[serde(
         serialize_with = "as_json_string",
         deserialize_with = "from_json_string"

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -50,6 +50,22 @@ where
     }
 
     ///
+    /// https://api.slack.com/methods/apps.manifest.delete
+    ///
+    pub async fn apps_manifest_delete(
+        &self,
+        req: &SlackApiAppsManifestDeleteRequest,
+    ) -> ClientResult<()> {
+        self.http_session_api
+            .http_post(
+                "apps.manifest.delete",
+                req,
+                Some(&SLACK_TIER1_METHOD_CONFIG),
+            )
+            .await
+    }
+
+    ///
     /// https://api.slack.com/methods/apps.manifest.export
     ///
     pub async fn apps_manifest_export(
@@ -113,6 +129,12 @@ pub struct SlackApiAppsManifestCreateResponse {
     pub app_id: SlackAppId,
     pub credentials: SlackAppCredentials,
     pub oauth_authorize_url: Url,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiAppsManifestDeleteRequest {
+    pub app_id: SlackAppId,
 }
 
 #[skip_serializing_none]

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -59,7 +59,7 @@ where
             .http_post(
                 "apps.manifest.update",
                 req,
-                Some(&SLACK_TIER3_METHOD_CONFIG),
+                Some(&SLACK_TIER1_METHOD_CONFIG),
             )
             .await
     }

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -31,6 +31,22 @@ where
             )
             .await
     }
+
+    ///
+    /// https://api.slack.com/methods/apps.manifest.export
+    ///
+    pub async fn apps_manifest_export(
+        &self,
+        req: &SlackApiAppsManifestExportRequest,
+    ) -> ClientResult<SlackApiAppsManifestExportResponse> {
+        self.http_session_api
+            .http_post(
+                "apps.manifest.export",
+                req,
+                Some(&SLACK_TIER3_METHOD_CONFIG),
+            )
+            .await
+    }
 }
 
 #[skip_serializing_none]
@@ -41,4 +57,16 @@ pub struct SlackApiAppsConnectionOpenRequest {}
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiAppsConnectionOpenResponse {
     pub url: SlackWebSocketsUrl,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiAppsManifestExportRequest {
+    pub app_id: SlackAppId,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiAppsManifestExportResponse {
+    pub manifest: SlackAppManifest,
 }

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -3,7 +3,7 @@
 //!
 
 use rsb_derive::Builder;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
 
@@ -130,12 +130,7 @@ pub struct SlackApiAppsManifestCreateRequest {
     pub app_id: SlackAppId,
 
     // HACK: This API requires a "json-encoded" string in a JSON object.
-    //       Using these `as_json_string` and `from_json_string` functions,
-    //       we enforce serde to encode or decode the field from/to JSON.
-    #[serde(
-        serialize_with = "as_json_string",
-        deserialize_with = "from_json_string"
-    )]
+    #[serde(with = "serde_with::json::nested")]
     pub manifest: SlackAppManifest,
 }
 
@@ -171,12 +166,7 @@ pub struct SlackApiAppsManifestUpdateRequest {
     pub app_id: SlackAppId,
 
     // HACK: This API requires a "json-encoded" string in a JSON object.
-    //       Using these `as_json_string` and `from_json_string` functions,
-    //       we enforce serde to encode or decode the field from/to JSON.
-    #[serde(
-        serialize_with = "as_json_string",
-        deserialize_with = "from_json_string"
-    )]
+    #[serde(with = "serde_with::json::nested")]
     pub manifest: SlackAppManifest,
 }
 
@@ -191,29 +181,8 @@ pub struct SlackApiAppsManifestUpdateResponse {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiAppsManifestValidateRequest {
     // HACK: This API requires a "json-encoded" string in a JSON object.
-    //       Using these `as_json_string` and `from_json_string` functions,
-    //       we enforce serde to encode or decode the field from/to JSON.
-    #[serde(
-        serialize_with = "as_json_string",
-        deserialize_with = "from_json_string"
-    )]
+    #[serde(with = "serde_with::json::nested")]
     pub manifest: SlackAppManifest,
 
     pub app_id: Option<SlackAppId>,
-}
-
-fn as_json_string<T, S>(x: &T, s: S) -> Result<S::Ok, S::Error>
-where
-    T: Serialize,
-    S: Serializer,
-{
-    s.serialize_str(&serde_json::to_string(x).map_err(serde::ser::Error::custom)?)
-}
-
-fn from_json_string<'de, T, D>(d: D) -> Result<T, D::Error>
-where
-    T: Deserialize<'de> + 'static,
-    D: Deserializer<'de>,
-{
-    serde_json::from_str(<&str>::deserialize(d)?).map_err(serde::de::Error::custom)
 }

--- a/src/client/src/api/apps.rs
+++ b/src/client/src/api/apps.rs
@@ -102,7 +102,7 @@ pub struct SlackApiAppsManifestUpdateRequest {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiAppsManifestUpdateResponse {
     pub app_id: SlackAppId,
-    pub permission_updated: bool,
+    pub permissions_updated: bool,
 }
 
 fn as_json_string<T, S>(x: &T, s: S) -> Result<S::Ok, S::Error>

--- a/src/client/src/client.rs
+++ b/src/client/src/client.rs
@@ -147,6 +147,8 @@ pub type AnyStdResult<T> = std::result::Result<T, Box<dyn std::error::Error + Se
 pub struct SlackEnvelopeMessage {
     pub ok: bool,
     pub error: Option<String>,
+    // apps.manifest.validate returns validation errors in `errors` field with `ok: false`.
+    pub errors: Option<Vec<String>>,
     pub warnings: Option<Vec<String>>,
 }
 

--- a/src/client/src/errors.rs
+++ b/src/client/src/errors.rs
@@ -57,6 +57,7 @@ impl Error for SlackClientError {
 #[derive(Debug, PartialEq, Clone, Builder)]
 pub struct SlackClientApiError {
     pub code: String,
+    pub errors: Option<Vec<String>>,
     pub warnings: Option<Vec<String>>,
     pub http_response_body: Option<String>,
 }

--- a/src/client/src/token.rs
+++ b/src/client/src/token.rs
@@ -5,6 +5,9 @@ use serde_with::skip_serializing_none;
 
 use slack_morphism_models::SlackTeamId;
 
+// Re-exports for backward compatibility
+pub use slack_morphism_models::SlackApiTokenScope;
+
 #[derive(Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackApiTokenValue(pub String);
 
@@ -13,9 +16,6 @@ impl std::fmt::Debug for SlackApiTokenValue {
         write!(f, "SlackApiTokenValue(len:{})", self.value().len())
     }
 }
-
-#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
-pub struct SlackApiTokenScope(pub String);
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
 pub enum SlackApiTokenType {

--- a/src/hyper/src/connector.rs
+++ b/src/hyper/src/connector.rs
@@ -192,6 +192,7 @@ impl<H: 'static + Send + Sync + Clone + connect::Connect> SlackClientHyperConnec
                     }
                     Some(slack_error) => Err(SlackClientError::ApiError(
                         SlackClientApiError::new(slack_error)
+                            .opt_errors(slack_message.errors)
                             .opt_warnings(slack_message.warnings)
                             .with_http_response_body(http_body_str),
                     )),

--- a/src/models/src/apps/manifest.rs
+++ b/src/models/src/apps/manifest.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
 
-use crate::{SlackApiTokenScope, SlackCallbackId, SlackShortcutType};
+use crate::{SlackApiTokenScope, SlackCallbackId, SlackEventType, SlackShortcutType};
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
@@ -25,8 +25,8 @@ pub struct SlackAppManifestDisplayInformation {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackAppManifestSettingsEventSubscriptions {
     pub request_url: Option<Url>,
-    pub bot_events: Option<Vec<String>>,
-    pub user_events: Option<Vec<String>>,
+    pub bot_events: Option<Vec<SlackEventType>>,
+    pub user_events: Option<Vec<SlackEventType>>,
 }
 
 #[skip_serializing_none]

--- a/src/models/src/apps/manifest.rs
+++ b/src/models/src/apps/manifest.rs
@@ -1,6 +1,9 @@
-use crate::events::SlackMessageEventType;
-use crate::{SlackCallbackId, SlackShortcutType};
+use rsb_derive::Builder;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use url::Url;
+
+use crate::{SlackCallbackId, SlackShortcutType};
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]

--- a/src/models/src/apps/manifest.rs
+++ b/src/models/src/apps/manifest.rs
@@ -1,0 +1,123 @@
+use crate::events::SlackMessageEventType;
+use crate::{SlackCallbackId, SlackShortcutType};
+use url::Url;
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestMetadata {
+    pub major_version: Option<usize>,
+    pub minor_version: Option<usize>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestDisplayInformation {
+    pub name: String,
+    pub description: Option<String>,
+    pub background_color: Option<String>,
+    pub long_description: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestSettingsEventSubscriptions {
+    pub request_url: Option<Url>,
+    pub bot_events: Option<Vec<String>>,
+    pub user_events: Option<Vec<String>>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestSettingsInteractivity {
+    pub is_enabled: bool,
+    pub request_url: Option<Url>,
+    pub message_menu_options_url: Option<Url>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestSettings {
+    pub allowed_ip_address_ranges: Option<Vec<String>>,
+    pub event_subscriptions: Option<SlackAppManifestSettingsEventSubscriptions>,
+    pub interactivity: Option<SlackAppManifestSettingsInteractivity>,
+    pub org_deploy_enabled: Option<bool>,
+    pub socket_mode_enabled: Option<bool>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestFeaturesAppHome {
+    pub home_tab_enabled: Option<bool>,
+    pub messages_tab_enabled: Option<bool>,
+    pub messages_tab_read_only_enabled: Option<bool>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestFeaturesBotUser {
+    pub display_name: String,
+    pub always_online: bool,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestFeaturesShortcut {
+    pub name: String,
+    pub callback_id: SlackCallbackId,
+    pub description: String,
+    #[serde(rename = "type")]
+    pub ty: SlackShortcutType,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestFeaturesSlashCommand {
+    pub command: String,
+    pub description: String,
+    pub should_escape: Option<bool>,
+    pub url: Option<Url>,
+    pub usage_hint: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestFeaturesWorkflowStep {
+    pub name: String,
+    pub callback_id: SlackCallbackId,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestFeatures {
+    pub app_home: Option<SlackAppManifestFeaturesAppHome>,
+    pub bot_user: Option<SlackAppManifestFeaturesBotUser>,
+    pub shortcuts: Option<Vec<SlackAppManifestFeaturesShortcut>>,
+    pub slash_commands: Option<Vec<SlackAppManifestFeaturesSlashCommand>>,
+    pub unfurl_domains: Option<Vec<String>>,
+    pub workflow_steps: Option<Vec<SlackAppManifestFeaturesWorkflowStep>>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestOAuthConfigScopes {
+    pub bot: Option<Vec<String>>,
+    pub user: Option<Vec<String>>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifestOAuthConfig {
+    pub redirect_urls: Option<Vec<Url>>,
+    pub scopes: Option<SlackAppManifestOAuthConfigScopes>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppManifest {
+    #[serde(rename = "_metadata")]
+    pub metadata: Option<SlackAppManifestMetadata>,
+    pub display_information: SlackAppManifestDisplayInformation,
+    pub settings: Option<SlackAppManifestSettings>,
+    pub features: Option<SlackAppManifestFeatures>,
+    pub oauth_config: Option<SlackAppManifestOAuthConfig>,
+}

--- a/src/models/src/apps/manifest.rs
+++ b/src/models/src/apps/manifest.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
 
-use crate::{SlackCallbackId, SlackShortcutType};
+use crate::{SlackApiTokenScope, SlackCallbackId, SlackShortcutType};
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
@@ -103,8 +103,8 @@ pub struct SlackAppManifestFeatures {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackAppManifestOAuthConfigScopes {
-    pub bot: Option<Vec<String>>,
-    pub user: Option<Vec<String>>,
+    pub bot: Option<Vec<SlackApiTokenScope>>,
+    pub user: Option<Vec<SlackApiTokenScope>>,
 }
 
 #[skip_serializing_none]

--- a/src/models/src/apps/mod.rs
+++ b/src/models/src/apps/mod.rs
@@ -1,0 +1,1 @@
+pub mod manifest;

--- a/src/models/src/apps/mod.rs
+++ b/src/models/src/apps/mod.rs
@@ -2,6 +2,10 @@ pub mod manifest;
 
 pub use manifest::*;
 
+use rsb_derive::Builder;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
 use crate::{SlackClientId, SlackClientSecret, SlackSigningSecret, SlackVerificationToken};
 
 #[skip_serializing_none]

--- a/src/models/src/apps/mod.rs
+++ b/src/models/src/apps/mod.rs
@@ -1,3 +1,14 @@
 pub mod manifest;
 
 pub use manifest::*;
+
+use crate::{SlackClientId, SlackClientSecret, SlackSigningSecret, SlackVerificationToken};
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackAppCredentials {
+    pub client_id: SlackClientId,
+    pub client_secret: SlackClientSecret,
+    pub verification_token: SlackVerificationToken,
+    pub signing_secret: SlackSigningSecret,
+}

--- a/src/models/src/apps/mod.rs
+++ b/src/models/src/apps/mod.rs
@@ -1,1 +1,3 @@
 pub mod manifest;
+
+pub use manifest::*;

--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -195,3 +195,6 @@ pub enum SlackShortcutType {
     #[serde(rename = "global")]
     Global,
 }
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
+pub struct SlackEventType(pub String);

--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -110,6 +110,9 @@ pub struct SlackClientId(pub String);
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackClientSecret(pub String);
 
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
+pub struct SlackApiTokenScope(pub String);
+
 #[derive(Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackVerificationToken(pub String);
 

--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -111,6 +111,12 @@ pub struct SlackClientId(pub String);
 pub struct SlackClientSecret(pub String);
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
+pub struct SlackVerificationToken(pub String);
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
+pub struct SlackSigningSecret(pub String);
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct EmailAddress(pub String);
 
 #[skip_serializing_none]

--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -172,3 +172,11 @@ impl SlackEmoji {
     pub const SPEECH_BALLOON: &'static str = ":speech_balloon:";
     pub const HEAVY_CHECK_MARK: &'static str = ":heavy_check_mark:";
 }
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum SlackShortcutType {
+    #[serde(rename = "message")]
+    Message,
+    #[serde(rename = "global")]
+    Global,
+}

--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -110,8 +110,14 @@ pub struct SlackClientId(pub String);
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackClientSecret(pub String);
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
+#[derive(Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackVerificationToken(pub String);
+
+impl fmt::Debug for SlackVerificationToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SlackVerificationToken(len:{})", self.value().len())
+    }
+}
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackSigningSecret(pub String);

--- a/src/models/src/lib.rs
+++ b/src/models/src/lib.rs
@@ -16,6 +16,7 @@ pub mod files;
 mod messages;
 pub mod socket_mode;
 
+pub use apps::*;
 pub use common::*;
 pub use files::*;
 pub use messages::*;

--- a/src/models/src/lib.rs
+++ b/src/models/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod common;
 
+pub mod apps;
 pub mod blocks;
 pub mod events;
 pub mod files;


### PR DESCRIPTION
This pull request adds support for these API methods:

- [apps.manifest.create](https://api.slack.com/methods/apps.manifest.create)
- [apps.manifest.delete](https://api.slack.com/methods/apps.manifest.delete)
- [apps.manifest.export](https://api.slack.com/methods/apps.manifest.export)
- [apps.manifest.update](https://api.slack.com/methods/apps.manifest.update)
- [apps.manifest.validate](https://api.slack.com/methods/apps.manifest.validate)

Note that:

- These APIs requires a special token: App Configuration Token, which can be issued in https://api.slack.com/authentication/config-tokens .
- These are in Beta.

Our internal pull request (in Japanese): https://github.com/yumemi-inc/slack-morphism-rust/pull/19