### PR TITLE
feat: Add reactions into SlackMessageContent struct

### DIFF
--- a/src/models/src/common/mod.rs
+++ b/src/models/src/common/mod.rs
@@ -14,6 +14,8 @@ mod team;
 pub use team::*;
 mod channel;
 pub use channel::*;
+mod reaction;
+pub use reaction::*;
 
 mod bot;
 pub use bot::*;

--- a/src/models/src/common/reaction.rs
+++ b/src/models/src/common/reaction.rs
@@ -1,0 +1,13 @@
+use crate::common::*;
+
+use rsb_derive::Builder;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackReaction {
+    pub name: String,
+    pub count: usize,
+    pub users: Vec<SlackUserId>,
+}

--- a/src/models/src/files/mod.rs
+++ b/src/models/src/files/mod.rs
@@ -36,6 +36,7 @@ pub struct SlackFile {
     pub url_private_download: Option<Url>,
     pub permalink: Option<Url>,
     pub permalink_public: Option<Url>,
+    pub reactions: Option<Vec<SlackReaction>>,
     #[serde(flatten)]
     pub flags: SlackFileFlags,
 }

--- a/src/models/src/messages/mod.rs
+++ b/src/models/src/messages/mod.rs
@@ -28,6 +28,7 @@ pub struct SlackMessageContent {
     pub attachments: Option<Vec<SlackMessageAttachment>>,
     pub upload: Option<bool>,
     pub files: Option<Vec<SlackFile>>,
+    pub reactions: Option<Vec<SlackReaction>>,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
This pull request proposes to add `reactions` field (of type `SlackReactions`), which is documented at https://api.slack.com/methods/reactions.get#examples .

Note that this field is filled only from `reactions.get` endpoint with the message that has any reaction(s), but this approach is better than defining another type for it to share other fields.