### PR TITLE
added support for emoji_changed event

### DIFF
--- a/src/models/src/events/push.rs
+++ b/src/models/src/events/push.rs
@@ -55,6 +55,7 @@ pub enum SlackEventCallbackBody {
     AppMention(SlackAppMentionEvent),
     AppUninstalled(SlackAppUninstalledEvent),
     LinkShared(SlackLinkSharedEvent),
+    EmojiChanged(SlackEmojiChangedEvent),
 }
 
 #[skip_serializing_none]
@@ -106,6 +107,8 @@ pub enum SlackMessageEventType {
     JoinerNotification,
     #[serde(rename = "slackbot_response")]
     SlackbotResponse,
+    #[serde(rename = "emoji_changed")]
+    EmojiChanged,
 }
 
 #[skip_serializing_none]
@@ -145,6 +148,28 @@ pub struct SlackLinkSharedEvent {
     pub source: String,
     pub unfurl_id: SlackUnfurlId,
     pub user: SlackUserId,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackEmojiChangedEvent {
+    pub subtype: Option<SlackEmojiEventType>,
+    pub name: Option<String>,
+    pub names: Option<Vec<String>>,
+    pub old_name: Option<String>,
+    pub new_name: Option<String>,
+    pub value: Option<Url>,
+    pub event_ts: SlackTs,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum SlackEmojiEventType {
+    #[serde(rename = "remove")]
+    EmojiRemoved,
+    #[serde(rename = "add")]
+    EmojiAdded,
+    #[serde(rename = "rename")]
+    EmojiRenamed,
 }
 
 #[skip_serializing_none]

--- a/src/models/src/events/push.rs
+++ b/src/models/src/events/push.rs
@@ -153,7 +153,7 @@ pub struct SlackLinkSharedEvent {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackEmojiChangedEvent {
-    pub subtype: Option<SlackEmojiEventType>,
+    pub subtype: SlackEmojiEventType,
     pub name: Option<String>,
     pub names: Option<Vec<String>>,
     pub old_name: Option<String>,


### PR DESCRIPTION
Hello! 👋🏼 

Thanks for putting this together! I was doing a small hackathon and noticed there wasn't support for the [emoji_changed](https://api.slack.com/events/emoji_changed) event, so I figured why not add it :D 

Let me know if I missed anything, still trying to learn Rust!