### PR TITLE
Support ViewSubmissionResponse for slack app interactivity

### DIFF
--- a/src/models/events/mod.rs
+++ b/src/models/events/mod.rs
@@ -5,11 +5,13 @@ mod authorization;
 mod command;
 mod interaction;
 mod push;
+mod view;
 
 pub use authorization::*;
 pub use command::*;
 pub use interaction::*;
 pub use push::*;
+pub use view::*;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackEventId(pub String);

--- a/src/models/events/view.rs
+++ b/src/models/events/view.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+use rsb_derive::Builder;
+use serde::{Deserialize, Serialize};
+
+use crate::blocks::SlackView;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(tag = "response_action")]
+pub enum SlackViewSubmissionResponse {
+    #[serde(rename = "clear")]
+    Clear(SlackViewSubmissionClearResponse),
+    #[serde(rename = "update")]
+    Update(SlackViewSubmissionUpdateResponse),
+    #[serde(rename = "push")]
+    Push(SlackViewSubmissionPushResponse),
+    #[serde(rename = "errors")]
+    Errors(SlackViewSubmissionErrorsResponse),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackViewSubmissionClearResponse {}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackViewSubmissionUpdateResponse {
+    pub view: SlackView,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackViewSubmissionPushResponse {
+    pub view: SlackView,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackViewSubmissionErrorsResponse {
+    pub errors: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_slack_view_submission_clear_response_serialization() {
+        let output = serde_json::to_string(&SlackViewSubmissionResponse::Clear(
+            SlackViewSubmissionClearResponse::new(),
+        ))
+        .unwrap();
+        assert_eq!(output, r#"{"response_action":"clear"}"#);
+    }
+}


### PR DESCRIPTION
I added `ViewSubmissionResponse` used for slack app interactivity request.

I confused about location of the file. Is there any better location?

ref. https://github.com/slack-go/slack/blob/master/views.go