### PR TITLE
Distributed tracing (spans) support, scope propagation and `SlackClient.run_in_session` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,11 @@ path = "examples/client.rs"
 required-features = ["hyper"]
 
 [[example]]
+name = "client_with_tracing"
+path = "examples/client_with_tracing.rs"
+required-features = ["hyper"]
+
+[[example]]
 name = "events_api_server"
 path = "examples/events_api_server.rs"
 required-features = ["hyper"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-morphism"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Abdulla Abdurakhmanov <me@abdolence.dev>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Send webhook messages](./send-webhooks-messages.md)
   - [Hyper connection types and proxy support](./hyper-connections-types.md)
   - [Rate control and retries](./rate-control-and-retries.md)
+  - [Observability and tracing](./observability-tracing.md)
 - [Events API](./events-api.md)
   - [Hyper-based](./events-api-hyper.md)
   - [Axum-based](./events-api-axum.md)

--- a/docs/src/observability-tracing.md
+++ b/docs/src/observability-tracing.md
@@ -1,0 +1,32 @@
+# Observability and tracing
+
+The library uses popular `tracing` crate for logs and distributed traces (spans).
+To improve observability for your specific cases, additionally to the fields provided by library,  you can inject your own trace fields:
+
+```rust,noplaypen
+use slack_morphism::prelude::*;
+use tracing::*;
+
+// While Team ID is optional but still useful for tracing and rate control purposes
+let token: SlackApiToken =
+    SlackApiToken::new(token_value).with_team_id(config_env_var("SLACK_TEST_TEAM_ID")?.into());
+
+// Sessions are lightweight and basically just a reference to client and token
+let my_custom_span = span!(Level::DEBUG, "My scope", my_scope_attr = "my-scope-value");
+debug!("Testing tracing abilities");
+
+client
+    .run_in_session(&token, |session| async move {
+        let test: SlackApiTestResponse = session
+            .api_test(&SlackApiTestRequest::new().with_foo("Test".into()))
+            .await?;
+        println!("{:#?}", test);
+
+        let auth_test = session.auth_test().await?;
+        println!("{:#?}", auth_test);
+
+        Ok(())
+    })
+    .instrument(my_custom_span.or_current())
+    .await
+```

--- a/docs/src/web-api.md
+++ b/docs/src/web-api.md
@@ -53,8 +53,9 @@ async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 ```
 
-Not that `session` is just auxiliary lightweight structure that stores references to the token and client to make
-easier to have series of calls for the same token. It doesn't make any network calls. There is no need to store it.
+Note that `session` is just an auxiliary lightweight structure that stores references to the token and the client
+to make easier to have series of calls for the same token.
+It doesn't make any network calls. There is no need to store it.
 
 Another option is to use `session` is to use function `run_in_session`:
 

--- a/docs/src/web-api.md
+++ b/docs/src/web-api.md
@@ -52,3 +52,26 @@ async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 ```
+
+Not that `session` is just auxiliary lightweight structure that stores references to the token and client to make
+easier to have series of calls for the same token. It doesn't make any network calls. There is no need to store it.
+
+Another option is to use `session` is to use function `run_in_session`:
+
+```rust,noplaypen
+    // Sessions are lightweight and basically just a reference to client and token
+    client
+        .run_in_session(&token, |session| async move {
+            let test: SlackApiTestResponse = session
+                .api_test(&SlackApiTestRequest::new().with_foo("Test".into()))
+                .await?;
+
+            println!("{:#?}", test);
+
+            let auth_test = session.auth_test().await?;
+            println!("{:#?}", auth_test);
+
+            Ok(())
+        })
+        .await?;
+```

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -163,31 +163,6 @@ impl SlackBlocksTemplate for SlackHomeTabBlocksTemplateExample {
     }
 }
 
-async fn test_simple_api_calls_as_predicate() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
-{
-    let client = SlackClient::new(SlackClientHyperConnector::new());
-    let token_value: SlackApiTokenValue = config_env_var("SLACK_TEST_TOKEN")?.into();
-    let token: SlackApiToken = SlackApiToken::new(token_value);
-
-    // Sessions are lightweight and basically just a reference to client and token
-    client
-        .run_in_session(&token, |session| async move {
-            println!("{:#?}", session);
-
-            let test: SlackApiTestResponse = session
-                .api_test(&SlackApiTestRequest::new().with_foo("Test".into()))
-                .await?;
-
-            println!("{:#?}", test);
-
-            let auth_test = session.auth_test().await?;
-            println!("{:#?}", auth_test);
-
-            Ok(())
-        })
-        .await
-}
-
 pub fn config_env_var(name: &str) -> Result<String, String> {
     std::env::var(name).map_err(|e| format!("{}: {}", name, e))
 }
@@ -202,7 +177,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     test_simple_api_calls().await?;
     test_post_message().await?;
     test_scrolling_user_list().await?;
-    test_simple_api_calls_as_predicate().await?;
 
     Ok(())
 }

--- a/examples/client_with_tracing.rs
+++ b/examples/client_with_tracing.rs
@@ -1,0 +1,45 @@
+use slack_morphism::prelude::*;
+use tracing::*;
+
+async fn test_simple_api_calls_as_predicate() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+{
+    let client = SlackClient::new(SlackClientHyperConnector::new());
+    let token_value: SlackApiTokenValue = config_env_var("SLACK_TEST_TOKEN")?.into();
+    let token: SlackApiToken =
+        SlackApiToken::new(token_value).with_team_id(config_env_var("SLACK_TEST_TEAM_ID")?.into()); // While Team ID is optional but still useful for tracing and rate control purposes
+
+    // Sessions are lightweight and basically just a reference to client and token
+    let my_custom_span = span!(Level::DEBUG, "My scope", my_scope_attr = "my-scope-value");
+    debug!("Testing tracing abilities");
+
+    client
+        .run_in_session(&token, |session| async move {
+            let test: SlackApiTestResponse = session
+                .api_test(&SlackApiTestRequest::new().with_foo("Test".into()))
+                .await?;
+            println!("{:#?}", test);
+
+            let auth_test = session.auth_test().await?;
+            println!("{:#?}", auth_test);
+
+            Ok(())
+        })
+        .instrument(my_custom_span.or_current())
+        .await
+}
+
+pub fn config_env_var(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|e| format!("{}: {}", name, e))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter("client_with_tracing=debug,slack_morphism=debug")
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    test_simple_api_calls_as_predicate().await?;
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 use std::sync::Arc;
 
 use crate::token::*;
@@ -217,6 +218,15 @@ where
         };
 
         SlackClientSession { http_session_api }
+    }
+
+    pub async fn run_in_session<'a, FN, F, T>(&'a self, token: &'a SlackApiToken, pred: FN) -> T
+    where
+        FN: Fn(SlackClientSession<'a, SCHC>) -> F,
+        F: Future<Output = T>,
+    {
+        let session = self.open_session(token);
+        pred(session).await
     }
 }
 


### PR DESCRIPTION

Another option is to use `session` is to use function `run_in_session`:

```rust,noplaypen
    // Sessions are lightweight and basically just a reference to client and token
    client
        .run_in_session(&token, |session| async move {
            let test: SlackApiTestResponse = session
                .api_test(&SlackApiTestRequest::new().with_foo("Test".into()))
                .await?;
            println!("{:#?}", test);
            let auth_test = session.auth_test().await?;
            println!("{:#?}", auth_test);
            Ok(())
        })
        .await?;
```

Tracing example:
```rust
    let token: SlackApiToken =
        SlackApiToken::new(token_value).with_team_id(config_env_var("SLACK_TEST_TEAM_ID")?.into()); // While Team ID is optional but still useful for tracing and rate control purposes

    // Sessions are lightweight and basically just a reference to client and token
    let my_custom_span = span!(Level::DEBUG, "My scope", my_scope_attr = "my-scope-value");
    debug!("Testing tracing abilities");

    client
        .run_in_session(&token, |session| async move {
            let test: SlackApiTestResponse = session
                .api_test(&SlackApiTestRequest::new().with_foo("Test".into()))
                .await?;
            println!("{:#?}", test);

            let auth_test = session.auth_test().await?;
            println!("{:#?}", auth_test);

            Ok(())
        })
        .instrument(my_custom_span.or_current())
        .await
```