### PR TITLE
Add the reactions.add and reactions.remove api. Fix typo in converations_replies.

### DIFF
--- a/src/api/conversations.rs
+++ b/src/api/conversations.rs
@@ -279,7 +279,7 @@ where
                 "conversations.replies",
                 &vec![
                     ("channel", Some(req.channel.value())),
-                    ("ts", Some(req.channel.value())),
+                    ("ts", Some(req.ts.value())),
                     ("cursor", req.cursor.as_ref().map(|x| x.value())),
                     ("limit", req.limit.map(|v| v.to_string()).as_ref()),
                     ("inclusive", req.inclusive.map(|v| v.to_string()).as_ref()),

--- a/src/api/reactions.rs
+++ b/src/api/reactions.rs
@@ -37,6 +37,30 @@ where
             )
             .await
     }
+
+    ///
+    /// https://api.slack.com/methods/reactions.add
+    ///
+    pub async fn reactions_add(
+        &self,
+        req: &SlackApiReactionsAddRequest,
+    ) -> ClientResult<SlackApiReactionsAddResponse> {
+        self.http_session_api
+            .http_post("reactions.add", req, Some(&SLACK_TIER3_METHOD_CONFIG))
+            .await
+    }
+
+    ///
+    /// https://api.slack.com/methods/reactions.remove
+    ///
+    pub async fn reactions_remove(
+        &self,
+        req: &SlackApiReactionsRemoveRequest,
+    ) -> ClientResult<SlackApiReactionsRemoveResponse> {
+        self.http_session_api
+            .http_post("reactions.remove", req, Some(&SLACK_TIER2_METHOD_CONFIG))
+            .await
+    }
 }
 
 #[skip_serializing_none]
@@ -62,3 +86,29 @@ pub enum SlackApiReactionsGetResponse {
     Message(SlackApiReactionsGetMessageResponse),
     File(SlackFile),
 }
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiReactionsAddRequest {
+    pub channel: SlackChannelId,
+    pub name: SlackReactionName,
+    pub timestamp: SlackTs,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiReactionsAddResponse {}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiReactionsRemoveRequest {
+    pub name: SlackReactionName,
+    pub channel: Option<SlackChannelId>,
+    pub file: Option<SlackFileId>,
+    pub full: Option<bool>,
+    pub timestamp: Option<SlackTs>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackApiReactionsRemoveResponse {}

--- a/src/models/common/reaction.rs
+++ b/src/models/common/reaction.rs
@@ -1,6 +1,7 @@
 use crate::*;
 
 use rsb_derive::Builder;
+use rvstruct::ValueStruct;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -11,3 +12,7 @@ pub struct SlackReaction {
     pub count: usize,
     pub users: Vec<SlackUserId>,
 }
+
+#[skip_serializing_none]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
+pub struct SlackReactionName(pub String);


### PR DESCRIPTION
Related to #153 

This adds:
* reactions.add
* reactions.remove
* Fixes bug in conversations.replies where timestamp was being passed in as channel.

Tested by updating the Cargo.toml of my Slackbot to point to my local crate path and added/removed reactions in my Slack workspace successfully.