### PR TITLE
BlockKit Model fixes

### DIFF
--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -333,7 +333,7 @@ pub struct SlackBlockOptionGroup<T: Into<SlackBlockText>> {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockStaticSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub options: Option<Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>>>,
     pub option_groups: Option<Vec<SlackBlockOptionGroup<SlackBlockPlainTextOnly>>>,
     pub initial_option: Option<SlackBlockChoiceItem<SlackBlockPlainTextOnly>>,
@@ -356,7 +356,7 @@ impl From<SlackBlockStaticSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockMultiStaticSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub options: Option<Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>>>,
     pub option_groups: Option<Vec<SlackBlockOptionGroup<SlackBlockPlainTextOnly>>>,
     pub initial_options: Option<Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>>>,
@@ -380,7 +380,7 @@ impl From<SlackBlockMultiStaticSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockExternalSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_option: Option<SlackBlockChoiceItem<SlackBlockPlainTextOnly>>,
     pub confirm: Option<SlackBlockConfirmItem>,
 }
@@ -401,7 +401,7 @@ impl From<SlackBlockExternalSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockMultiExternalSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_options: Option<Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>>>,
     pub confirm: Option<SlackBlockConfirmItem>,
     pub max_selected_items: Option<u64>,
@@ -423,7 +423,7 @@ impl From<SlackBlockMultiExternalSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockUsersSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_user: Option<String>,
     pub confirm: Option<SlackBlockConfirmItem>,
 }
@@ -444,7 +444,7 @@ impl From<SlackBlockUsersSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockMultiUsersSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_users: Option<Vec<String>>,
     pub confirm: Option<SlackBlockConfirmItem>,
     pub max_selected_items: Option<u64>,
@@ -466,7 +466,7 @@ impl From<SlackBlockMultiUsersSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockConversationsSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_conversation: Option<SlackConversationId>,
     pub default_to_current_conversation: Option<bool>,
     pub confirm: Option<SlackBlockConfirmItem>,
@@ -489,7 +489,7 @@ impl From<SlackBlockConversationsSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockMultiConversationsSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_conversations: Option<Vec<SlackConversationId>>,
     pub default_to_current_conversation: Option<bool>,
     pub confirm: Option<SlackBlockConfirmItem>,
@@ -512,7 +512,7 @@ impl From<SlackBlockMultiConversationsSelectElement> for SlackInputBlockElement 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockChannelsSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_channel: Option<SlackChannelId>,
     pub confirm: Option<SlackBlockConfirmItem>,
     pub response_url_enabled: Option<bool>,
@@ -534,7 +534,7 @@ impl From<SlackBlockChannelsSelectElement> for SlackInputBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockMultiChannelsSelectElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_channels: Option<Vec<SlackChannelId>>,
     pub confirm: Option<SlackBlockConfirmItem>,
     pub max_selected_items: Option<u64>,
@@ -576,7 +576,7 @@ impl From<SlackBlockOverflowElement> for SlackActionBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockDatePickerElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_date: Option<String>,
     pub confirm: Option<SlackBlockConfirmItem>,
 }
@@ -603,7 +603,7 @@ impl From<SlackBlockDatePickerElement> for SlackActionBlockElement {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockPlainTextInputElement {
     pub action_id: SlackActionId,
-    pub placeholder: SlackBlockPlainTextOnly,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
     pub initial_value: Option<String>,
     pub multiline: Option<bool>,
     pub min_length: Option<u64>,

--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -183,6 +183,10 @@ pub enum SlackSectionBlockElement {
     DatePicker(SlackBlockDatePickerElement),
     #[serde(rename = "plain_text_input")]
     PlainTextInput(SlackBlockPlainTextInputElement),
+    #[serde(rename = "number_input")]
+    NumberInput(SlackBlockNumberInputElement),
+    #[serde(rename = "url_text_input")]
+    UrlInput(SlackBlockUrlInputElement),
     #[serde(rename = "radio_buttons")]
     RadioButtons(SlackBlockRadioButtonsElement),
     #[serde(rename = "checkboxes")]
@@ -200,6 +204,10 @@ pub enum SlackActionBlockElement {
     DatePicker(SlackBlockDatePickerElement),
     #[serde(rename = "plain_text_input")]
     PlainTextInput(SlackBlockPlainTextInputElement),
+    #[serde(rename = "number_input")]
+    NumberInput(SlackBlockNumberInputElement),
+    #[serde(rename = "url_text_input")]
+    UrlInput(SlackBlockUrlInputElement),
     #[serde(rename = "radio_buttons")]
     RadioButtons(SlackBlockRadioButtonsElement),
     #[serde(rename = "checkboxes")]
@@ -244,6 +252,10 @@ pub enum SlackInputBlockElement {
     DatePicker(SlackBlockDatePickerElement),
     #[serde(rename = "plain_text_input")]
     PlainTextInput(SlackBlockPlainTextInputElement),
+    #[serde(rename = "number_input")]
+    NumberInput(SlackBlockNumberInputElement),
+    #[serde(rename = "url_text_input")]
+    UrlInput(SlackBlockUrlInputElement),
     #[serde(rename = "radio_buttons")]
     RadioButtons(SlackBlockRadioButtonsElement),
     #[serde(rename = "checkboxes")]
@@ -596,6 +608,26 @@ pub struct SlackBlockPlainTextInputElement {
     pub multiline: Option<bool>,
     pub min_length: Option<u64>,
     pub max_length: Option<u64>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackBlockNumberInputElement {
+    pub action_id: SlackActionId,
+    pub is_decimal_allowed: bool,
+    pub focus_on_load: Option<bool>,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
+    pub initial_value: Option<String>,
+    pub min_value: Option<String>,
+    pub max_value: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackBlockUrlInputElement {
+    pub action_id: SlackActionId,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
+    pub initial_value: Option<String>,
 }
 
 impl From<SlackBlockPlainTextInputElement> for SlackSectionBlockElement {


### PR DESCRIPTION
I've been playing around with a Slack Bot in Rust, and have run into some serde problems with using Block Kit. I've added the relevant models that I'm using, and adjusted the existing `placerholder` properties to match the [reference docs](https://api.slack.com/reference/block-kit/block-elements). 

* Added [NumberInput](https://api.slack.com/reference/block-kit/block-elements#number)
* Added [URLInput](https://api.slack.com/reference/block-kit/block-elements#url)
* Made `placeholder` optional across the models, since it doesn't seem to be required anywhere
