### PR TITLE
Derive Clone on SlackClient

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use rvstruct::ValueStruct;
 use tracing::*;
 use url::Url;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SlackClient<SCHC>
 where
     SCHC: SlackClientHttpConnector + Send,
@@ -21,7 +21,7 @@ where
     pub http_api: SlackClientHttpApi<SCHC>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SlackClientHttpApi<SCHC>
 where
     SCHC: SlackClientHttpConnector + Send,


### PR DESCRIPTION
`SlackClient` contains just an `Arc` to the underlying connector, so making it `Clone` seems natural and simplifies code that has to move the client (e.g. spawning an async task).