### PR TITLE
fix: Refactor SlackFile struct fields as optional

### DIFF
--- a/src/models/files/mod.rs
+++ b/src/models/files/mod.rs
@@ -22,9 +22,9 @@ pub struct SlackFileExternalType(pub String);
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackFile {
     pub id: SlackFileId,
-    pub created: SlackDateTime,
-    pub timestamp: SlackDateTime,
-    pub name: String,
+    pub created: Option<SlackDateTime>,
+    pub timestamp: Option<SlackDateTime>,
+    pub name: Option<String>,
     pub title: Option<String>,
     pub mimetype: Option<SlackMimeType>,
     pub filetype: Option<SlackFileType>,


### PR DESCRIPTION
I was running into a JSON parse error where the crated, timestamp and name fields were missing on the slack response. 

- Make fields `created`, `timestamp`, and `name` optional in `SlackFile` struct