### PR TITLE
Add several missing file events

### DIFF
--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -65,6 +65,11 @@ pub enum SlackEventCallbackBody {
     ChannelUnarchive(SlackChannelUnarchiveEvent),
     TeamJoin(SlackTeamJoinEvent),
     FileCreated(SlackFileCreatedEvent),
+    FileChange(SlackFileChangedEvent),
+    FileDeleted(SlackFileDeletedEvent),
+    FileShared(SlackFileSharedEvent),
+    FileUnshared(SlackFileUnsharedEvent),
+    FilePublic(SlackFilePublicEvent),
 }
 
 #[skip_serializing_none]
@@ -138,6 +143,16 @@ pub enum SlackMessageEventType {
     FileComment,
     #[serde(rename = "file_created")]
     FileCreated,
+    #[serde(rename = "file_change")]
+    FileChanged,
+    #[serde(rename = "file_deleted")]
+    FileDeleted,
+    #[serde(rename = "file_shared")]
+    FileShared,
+    #[serde(rename = "file_unshared")]
+    FileUnshared,
+    #[serde(rename = "file_public")]
+    FilePublic,
 }
 
 #[skip_serializing_none]
@@ -271,4 +286,38 @@ pub struct SlackFileCreatedEvent {
     pub user_id: SlackUserId, 
     pub file_id: SlackFileId,
     pub file: SlackFile,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackFileChangedEvent {
+    pub file_id: SlackFileId,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackFileDeletedEvent {
+    pub file_id: SlackFileId,
+    pub event_ts: SlackTs,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackFileSharedEvent {
+    pub channel_id: SlackChannelId,
+    pub file_id: SlackFileId,
+    pub user_id: SlackUserId,
+    pub event_ts: SlackTs,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackFileUnsharedEvent {
+    pub file_id: SlackFileId,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackFilePublicEvent {
+    pub file_id: SlackFileId,
 }

--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -64,6 +64,7 @@ pub enum SlackEventCallbackBody {
     ChannelRename(SlackChannelRenameEvent),
     ChannelUnarchive(SlackChannelUnarchiveEvent),
     TeamJoin(SlackTeamJoinEvent),
+    FileCreated(SlackFileCreatedEvent),
 }
 
 #[skip_serializing_none]
@@ -135,6 +136,8 @@ pub enum SlackMessageEventType {
     ReminderAdd,
     #[serde(rename = "file_comment")]
     FileComment,
+    #[serde(rename = "file_created")]
+    FileCreated,
 }
 
 #[skip_serializing_none]
@@ -260,4 +263,12 @@ pub struct SlackChannelUnarchiveEvent {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackTeamJoinEvent {
     pub user: SlackUser,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackFileCreatedEvent {
+    pub user_id: SlackUserId, 
+    pub file_id: SlackFileId,
+    pub file: SlackFile,
 }

--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -283,7 +283,7 @@ pub struct SlackTeamJoinEvent {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackFileCreatedEvent {
-    pub user_id: SlackUserId, 
+    pub user_id: SlackUserId,
     pub file_id: SlackFileId,
     pub file: SlackFile,
 }


### PR DESCRIPTION
This pull request adds the following Slack API events into `src/models/events/push.rs` that were missing:

- `file_created` (as `SlackFileCreatedEvent`)
- `file_change` (as `SlackFileChangedEvent`)
- `file_deleted` (as `SlackFileDeletedEvent`)
- `file_shared` (as `SlackFileSharedEvent`)
- `file_unshared` (as `SlackFileUnsharedEvent`)
- `file_public` (as `SlackFilePublicEvent`)

Adding these events help prevent protocol errors in socket mode when files are uploaded/deleted to the channel and a callback function has been set with `SlackSocketModeListenerCallbacks::with_push_events()`.

The fields in the event structs are copied from the Slack API documentation and named accordingly.