### PR TITLE
SlackMessageAttachment: add `text` field

### DIFF
--- a/src/models/messages/mod.rs
+++ b/src/models/messages/mod.rs
@@ -114,6 +114,7 @@ pub struct SlackMessageAttachment {
     pub title: Option<String>,
     pub fields: Option<Vec<SlackMessageAttachmentFieldObject>>,
     pub mrkdwn_in: Option<Vec<String>>,
+    pub text: Option<String>,
 }
 
 // This model is not well typed since Slack message attachments are deprecated


### PR DESCRIPTION
This field was missing from the `SlackMessageAttachment` object, was required in my use-case for parsing the full message object sent by a webhook.