### PR TITLE
fix!: Allow SlackUser.team_id to be optional, it is not returned on enterprise workspace

### DIFF
--- a/src/models/common/user.rs
+++ b/src/models/common/user.rs
@@ -10,7 +10,8 @@ use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackUser {
     pub id: SlackUserId,
-    pub team_id: SlackTeamId,
+    pub team_id: Option<SlackTeamId>,
+    pub teams: Option<Vec<SlackTeamId>>,
     pub name: Option<String>,
     pub locale: Option<SlackLocale>,
     pub profile: Option<SlackUserProfile>,


### PR DESCRIPTION
Today, Slack API suddenly stopped returning `team_id` on our enterprise workspace.
Instead, now the API returns `teams` with multiple team IDs in the enterprise.

This pull request changes `team_id` to `Option<SlackTeamId>` and adds `teams` field.

This is an example of `users.info` response:

```json
{
  "ok": true,
  "user": {
    "id": "[REDACTED]",
    "name": "n_ikeguchi",
    "deleted": false,
    "color": "8469bc",
    "real_name": "Natsuki Ikeguchi",
    "tz": "Asia\\/Tokyo",
    "tz_label": "Japan Standard Time",
    "tz_offset": 32400,
    "profile": {
      "title": "[REDACTED]",
      "phone": "[REDACTED]",
      "skype": "",
      "real_name": "Natsuki Ikeguchi",
      "real_name_normalized": "Natsuki Ikeguchi",
      "display_name": "siketyan",
      "display_name_normalized": "siketyan",
      "fields": null,
      "status_text": "[REDACTED]",
      "status_emoji": ":notes:",
      "status_emoji_display_info": [
        {
          "emoji_name": "notes",
          "display_url": "[REDACTED]",
          "unicode": "1f3b6"
        }
      ],
      "status_expiration": 0,
      "avatar_hash": "c4f7cfc76223",
      "image_original": "[REDACTED]",
      "is_custom_image": true,
      "huddle_state": "default_unset",
      "huddle_state_expiration_ts": 0,
      "first_name": "Natsuki",
      "last_name": "Ikeguchi",
      "image_24": "[REDACTED]",
      "image_32": "[REDACTED]",
      "image_48": "[REDACTED]",
      "image_72": "[REDACTED]",
      "image_192": "[REDACTED]",
      "image_512": "[REDACTED]",
      "image_1024": "[REDACTED]",
      "status_text_canonical": "",
      "team": "[REDACTED]"
    },
    "is_admin": false,
    "is_owner": false,
    "is_primary_owner": false,
    "is_restricted": false,
    "is_ultra_restricted": false,
    "is_bot": false,
    "is_app_user": false,
    "updated": 1698051971,
    "is_email_confirmed": true,
    "who_can_share_contact_card": "EVERYONE",
    "enterprise_user": {
      "id": "[REDACTED]",
      "enterprise_id": "[REDACTED]",
      "enterprise_name": "[REDACTED]",
      "is_admin": false,
      "is_owner": false,
      "is_primary_owner": false,
      "teams": [
        "[REDACTED]",
        "[REDACTED]",
        "[REDACTED]",
        "[REDACTED]",
        "[REDACTED]"
      ]
    },
    "enterprise_id": "[REDACTED]",
    "teams": [
      "[REDACTED]",
      "[REDACTED]",
      "[REDACTED]",
      "[REDACTED]",
      "[REDACTED]"
    ],
    "enterprise_name": "[REDACTED]"
  }
}
```