### PR TITLE
fix!: Include SlackMessageSender in SlackMessageEventEdited

### DIFF
--- a/src/models/events/fixtures/message_changed_by_bot.json
+++ b/src/models/events/fixtures/message_changed_by_bot.json
@@ -1,0 +1,92 @@
+{
+  "token": "XXXXXXXXXXXXXXXXXXXXXXXX",
+  "team_id": "TXXXXXXXXXX",
+  "context_team_id": "TXXXXXXXXXX",
+  "context_enterprise_id": null,
+  "api_app_id": "AXXXXXXXXXX",
+  "event": {
+    "type": "message",
+    "subtype": "message_changed",
+    "message": {
+      "client_msg_id": "000000000000000000000000000000000000",
+      "type": "message",
+      "text": "edited message",
+      "bot_id": "BXXXXXXXXXX",
+      "app_id": "AXXXXXXXXXX",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "wcwS3",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "hi!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "team": "TXXXXXXXXXX",
+      "edited": {
+        "user": "UXXXXXXXXXX",
+        "ts": "1701743154.000000"
+      },
+      "ts": "1701735043.989889",
+      "source_team": "TXXXXXXXXXX",
+      "user_team": "TXXXXXXXXXX"
+    },
+    "previous_message": {
+      "client_msg_id": "000000000000000000000000000000000000",
+      "type": "message",
+      "text": "hey!",
+      "bot_id": "BXXXXXXXXXX",
+      "app_id": "AXXXXXXXXXX",
+      "ts": "1701735043.989889",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "zUXnE",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "hey!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "team": "TXXXXXXXXXX",
+      "edited": {
+        "user": "UXXXXXXXXXX",
+        "ts": "1701742890.000000"
+      }
+    },
+    "channel": "CXXXXXXXXXX",
+    "hidden": true,
+    "ts": "1701743154.000500",
+    "event_ts": "1701743154.000500",
+    "channel_type": "group"
+  },
+  "type": "event_callback",
+  "event_id": "EXXXXXXXXXXX",
+  "event_time": 1701743154,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "TXXXXXXXXXX",
+      "user_id": "UXXXXXXXXXX",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+}

--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -386,6 +386,8 @@ mod test {
             }) => {
                 assert_eq!(subtype, Some(SlackMessageEventType::MessageChanged));
                 if let Some(message) = message {
+                    assert_eq!(message.sender.user, Some("UXXXXXXXXXX".into()));
+                    assert_eq!(message.sender.bot_id, None);
                     assert_eq!(message.ts, "1701735043.989889".into());
                     assert_eq!(message.edited.ts, "1701743154.000000".into());
                     assert_eq!(
@@ -410,6 +412,8 @@ mod test {
             }) => {
                 assert_eq!(subtype, Some(SlackMessageEventType::MessageChanged));
                 if let Some(message) = message {
+                    assert_eq!(message.sender.user, None);
+                    assert_eq!(message.sender.bot_id, Some("BXXXXXXXXXX".into()));
                     assert_eq!(message.ts, "1701735043.989889".into());
                     assert_eq!(message.edited.ts, "1701743154.000000".into());
                     assert_eq!(

--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -185,7 +185,8 @@ pub struct SlackAppMentionEvent {
 pub struct SlackMessageEventEdited {
     #[serde(flatten)]
     pub content: Option<SlackMessageContent>,
-    pub user: SlackUserId,
+    #[serde(flatten)]
+    pub sender: SlackMessageSender,
     pub ts: SlackTs,
     pub edited: SlackMessageEdited,
 }
@@ -378,6 +379,30 @@ mod test {
     #[test]
     fn test_slack_event_message_change_event() {
         let payload = include_str!("./fixtures/message_changed.json");
+        let event: SlackPushEventCallback = serde_json::from_str(payload).unwrap();
+        match event.event {
+            SlackEventCallbackBody::Message(SlackMessageEvent {
+                subtype, message, ..
+            }) => {
+                assert_eq!(subtype, Some(SlackMessageEventType::MessageChanged));
+                if let Some(message) = message {
+                    assert_eq!(message.ts, "1701735043.989889".into());
+                    assert_eq!(message.edited.ts, "1701743154.000000".into());
+                    assert_eq!(
+                        message.content.unwrap().text,
+                        Some("edited message".to_string())
+                    );
+                } else {
+                    panic!("Message is None");
+                }
+            }
+            _ => panic!("Unexpected event type"),
+        }
+    }
+
+    #[test]
+    fn test_slack_event_message_changed_by_bot_event() {
+        let payload = include_str!("./fixtures/message_changed_by_bot.json");
         let event: SlackPushEventCallback = serde_json::from_str(payload).unwrap();
         match event.event {
             SlackEventCallbackBody::Message(SlackMessageEvent {


### PR DESCRIPTION
Closes #229 

This pull request proposes to use `SlackMessageSender` instead of only `SlackUserId` in `SlackMessageEventEdited` struct. This also changes `user` field to optional and supports `bot_id`.

> [!Warning]
> BREAKING CHANGE: SlackMessageEventEdited::user is moved to sender.user and now it is optional.
