### PR TITLE
feat: Add support for stars events

### DIFF
--- a/src/models/common/mod.rs
+++ b/src/models/common/mod.rs
@@ -16,6 +16,8 @@ mod channel;
 pub use channel::*;
 mod reaction;
 pub use reaction::*;
+mod star;
+pub use star::*;
 
 mod bot;
 pub use bot::*;

--- a/src/models/common/star.rs
+++ b/src/models/common/star.rs
@@ -1,0 +1,66 @@
+use crate::*;
+
+use rsb_derive::Builder;
+use rvstruct::ValueStruct;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "lowercase")]
+#[allow(clippy::large_enum_variant)]
+pub enum SlackStarsItem {
+    Message(SlackStarsItemMessage),
+    File(SlackStarsItemFile),
+    #[serde(rename = "file_comment")]
+    FileComment(SlackStarsItemFileComment),
+    Channel(SlackStarsItemChannel),
+    Im(SlackStarsItemIm),
+    Group(SlackStarsItemGroup),
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarsItemMessage {
+    message: SlackHistoryMessage,
+    channel: SlackChannelId,
+    date_create: SlackDateTime,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarsItemFile {
+    file: SlackFile,
+    channel: SlackChannelId,
+    date_create: SlackDateTime,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarsItemFileComment {
+    file: SlackFile,
+    comment: String,
+    channel: SlackChannelId,
+    date_create: SlackDateTime,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarsItemChannel {
+    channel: SlackChannelId,
+    date_create: SlackDateTime,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarsItemIm {
+    channel: SlackChannelId,
+    date_create: SlackDateTime,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarsItemGroup {
+    group: SlackChannelId,
+    date_create: SlackDateTime,
+}

--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -72,6 +72,8 @@ pub enum SlackEventCallbackBody {
     FilePublic(SlackFilePublicEvent),
     ReactionAdded(SlackReactionAddedEvent),
     ReactionRemoved(SlackReactionRemovedEvent),
+    StarAdded(SlackStarAddedEvent),
+    StarRemoved(SlackStarRemovedEvent),
     UserChange(SlackUserChangeEvent),
     UserStatusChanged(SlackUserStatusChangedEvent),
 }
@@ -353,6 +355,22 @@ pub struct SlackReactionRemovedEvent {
     pub reaction: SlackReactionName,
     pub item_user: Option<SlackUserId>,
     pub item: SlackReactionsItem,
+    pub event_ts: SlackTs,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarAddedEvent {
+    pub user: SlackUserId,
+    pub item: SlackStarsItem,
+    pub event_ts: SlackTs,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackStarRemovedEvent {
+    pub user: SlackUserId,
+    pub item: SlackStarsItem,
     pub event_ts: SlackTs,
 }
 


### PR DESCRIPTION
Add support for `star_added` and `star_removed` Slack events. 
It has now been renamed "saved for later" in the Slack UI.