### PR TITLE
fix: Make `user_id` attribute on `SlackBotInfo`

### DIFF
--- a/src/models/common/bot.rs
+++ b/src/models/common/bot.rs
@@ -11,7 +11,7 @@ pub struct SlackBotInfo {
     pub name: String,
     pub updated: Option<SlackDateTime>,
     pub app_id: String,
-    pub user_id: String,
+    pub user_id: Option<String>,
     #[serde(flatten)]
     pub icons: Option<SlackIconImages>,
 }


### PR DESCRIPTION
According to the [Slack documentation](https://api.slack.com/methods/bots.info), `user_id` is optional:

> If the bot corresponds directly to a bot user account, the bot will also have a `user_id`