### PR TITLE
Support passing cookie with token

### DIFF
--- a/src/hyper_tokio/hyper_ext.rs
+++ b/src/hyper_tokio/hyper_ext.rs
@@ -43,7 +43,12 @@ impl HyperExtensions {
             request_builder
         } else {
             let token_header_value = format!("Bearer {}", token.unwrap().token_value.value());
-            request_builder.header(hyper::header::AUTHORIZATION, token_header_value)
+            let mut builder =
+                request_builder.header(hyper::header::AUTHORIZATION, token_header_value);
+            if let Some(cookie) = token.unwrap().cookie.clone() {
+                builder = builder.header(hyper::header::COOKIE, cookie.value())
+            }
+            builder
         }
     }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -14,6 +14,15 @@ impl std::fmt::Debug for SlackApiTokenValue {
     }
 }
 
+#[derive(Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
+pub struct SlackApiCookieValue(pub String);
+
+impl std::fmt::Debug for SlackApiCookieValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SlackApiCookieValue(len:{})", self.value().len())
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
 pub enum SlackApiTokenType {
     #[serde(rename = "bot")]
@@ -39,6 +48,7 @@ impl ToString for SlackApiTokenType {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiToken {
     pub token_value: SlackApiTokenValue,
+    pub cookie: Option<SlackApiCookieValue>,
     pub team_id: Option<SlackTeamId>,
     pub scope: Option<SlackApiTokenScope>,
     pub token_type: Option<SlackApiTokenType>,


### PR DESCRIPTION
User session token (`xoxc-...`) requires a special cookie (`d=xoxd-...`) to be set for all requests. This PR adds support of setting a custom cookie to support such cookies.

See https://papermtn.co.uk/retrieving-and-using-slack-cookies-for-authentication/ for information, as `xoxc-..` tokens are mysteriously not documented in [official Slack docs](https://api.slack.com/concepts/token-types).