### PR TITLE
Add `blocks` to message attachment

### DIFF
--- a/src/models/messages/mod.rs
+++ b/src/models/messages/mod.rs
@@ -115,6 +115,7 @@ pub struct SlackMessageAttachment {
     pub fields: Option<Vec<SlackMessageAttachmentFieldObject>>,
     pub mrkdwn_in: Option<Vec<String>>,
     pub text: Option<String>,
+    pub blocks: Option<Vec<SlackBlock>>,
 }
 
 // This model is not well typed since Slack message attachments are deprecated


### PR DESCRIPTION
Some Slack message blocks may be found as attachments to a message.
Even if attachments are deprecated, as of now, they are still here 🤷 