### PR TITLE
Add name fields to SlackCommandEvent

### DIFF
--- a/src/models/events/command.rs
+++ b/src/models/events/command.rs
@@ -8,7 +8,9 @@ use crate::*;
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackCommandEvent {
     pub team_id: SlackTeamId,
+    pub team_domain: Option<String>,
     pub channel_id: SlackChannelId,
+    pub channel_name: Option<String>,
     pub user_id: SlackUserId,
     pub command: SlackCommandId,
     pub text: Option<String>,


### PR DESCRIPTION
Adds `team_domain` and `channel_name` fields to `SlackCommandEvent`. I use this library for my company's project and noticed they're missing.



From slack doc: https://api.slack.com/interactivity/slash-commands#app_command_handling 

> team_id, enterprise_id, channel_id, etc.
> The various accompanying *_name values provide you with the plain text names for these IDs

In the payload example, `team_domain` and `channel_name` are present. 



