### PR TITLE
Add external select menu support

### DIFF
--- a/src/models/events/interaction.rs
+++ b/src/models/events/interaction.rs
@@ -53,6 +53,7 @@ pub struct SlackInteractionBlockSuggestionEvent {
     pub container: SlackInteractionActionContainer,
     pub view: Option<SlackView>,
     pub value: String,
+    pub message: Option<SlackHistoryMessage>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/src/models/events/interaction.rs
+++ b/src/models/events/interaction.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 pub enum SlackInteractionEvent {
     #[serde(rename = "block_actions")]
     BlockActions(SlackInteractionBlockActionsEvent),
+    #[serde(rename = "block_suggestion")]
+    BlockSuggestion(SlackInteractionBlockSuggestionEvent),
     #[serde(rename = "dialog_submission")]
     DialogSubmission(SlackInteractionDialogueSubmissionEvent),
     #[serde(rename = "message_action")]
@@ -38,6 +40,19 @@ pub struct SlackInteractionBlockActionsEvent {
     pub response_url: Option<SlackResponseUrl>,
     pub actions: Option<Vec<SlackInteractionActionInfo>>,
     pub state: Option<SlackActionState>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackInteractionBlockSuggestionEvent {
+    pub team: SlackBasicTeamInfo,
+    pub user: SlackBasicUserInfo,
+    pub api_app_id: SlackAppId,
+    pub block_id: SlackBlockId,
+    pub action_id: SlackActionId,
+    pub container: SlackInteractionActionContainer,
+    pub view: Option<SlackView>,
+    pub value: String,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -130,4 +145,23 @@ pub struct SlackInteractionViewClosedEvent {
     pub user: SlackBasicUserInfo,
     pub view: SlackStatefulView,
     pub trigger_id: Option<SlackTriggerId>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SlackBlockSuggestionResponse {
+    Options(SlackBlockSuggestionOptions),
+    OptionGroups(SlackBlockSuggestionOptionGroups),
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackBlockSuggestionOptions {
+    pub options: Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackBlockSuggestionOptionGroups {
+    pub option_groups: Vec<SlackBlockOptionGroup<SlackBlockPlainTextOnly>>,
 }


### PR DESCRIPTION
## Overview

Adding block_suggestion interaction event support. 

> A block_suggestion payload is received when a user interacts with a [select menu of external data source](https://api.slack.com/reference/block-kit/block-elements#external_select) element. Users may return a maximum of 100 options or option groups when handling the block_suggestion payload.

* Add `BlockSuggestion` to `SlackInteractionEvent`.  https://api.slack.com/reference/interaction-payloads/block-suggestion
* Add `SlackBlockSuggestionResponse`.  https://api.slack.com/reference/block-kit/block-elements#external_select
  * Implement `SlackInteractionEventResponse` for hyper_tokio listener

Closes https://github.com/abdolence/slack-morphism-rust/issues/186