### PR TITLE
fix: Update `SlackUserGroup.user_count` JSON type

### DIFF
--- a/src/models/common/user.rs
+++ b/src/models/common/user.rs
@@ -91,7 +91,6 @@ pub struct SlackUserGroup {
     pub deleted_by: Option<SlackUserId>,
     pub prefs: SlackUserGroupPrefs,
     pub users: Option<Vec<SlackUserId>>,
-    #[serde_as(as = "DisplayFromStr")]
     pub user_count: usize,
     pub channel_count: Option<u64>,
 }


### PR DESCRIPTION
Slack sends an integer in the `user_count` field of a user group, there is no need to try to parse it as a string.

The example in the [Slack documentation](https://api.slack.com/methods/usergroups.list) is wrong as the `user_count` is a string but when using "Tester", the `user_count` is an integer.
