### PR TITLE
Add more parent message params

### DIFF
--- a/src/models/messages/mod.rs
+++ b/src/models/messages/mod.rs
@@ -55,6 +55,8 @@ pub struct SlackParentMessageParams {
     pub reply_users_count: Option<usize>,
     pub latest_reply: Option<SlackTs>,
     pub reply_users: Option<Vec<SlackUserId>>,
+    pub subscribed: Option<bool>,
+    pub last_read: Option<SlackTs>,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
Parent message can have the following params:
- `subscribed` when the user has subscribed to a Slack thread
- `last_read` with the `SlackTs` of the latest read message in a Slack thread