### PR TITLE
Add user and bot profiles embedded in a message

### DIFF
--- a/src/models/messages/mod.rs
+++ b/src/models/messages/mod.rs
@@ -46,6 +46,8 @@ pub struct SlackMessageSender {
     pub bot_id: Option<SlackBotId>,
     pub username: Option<String>,
     pub display_as_bot: Option<bool>,
+    pub user_profile: Option<SlackUserProfile>,
+    pub bot_profile: Option<SlackBotInfo>,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
When retrieving a Slack thread using `conversations.replies`, the returned messages may embed a `user_profile` or `bot_profile`.
For example, it happens when the message sender is external to the Slack workspace requested.