### PR TITLE
refactor: make multipart_form public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod scroller;
 pub mod signature_verifier;
 pub mod socket_mode;
 
-mod multipart_form;
+pub mod multipart_form;
 mod token;
 
 #[cfg(feature = "hyper")]


### PR DESCRIPTION
I am implementing a custom connector and this module is necessary in order to implement the connector trait (unless I am doing something wrong?).

This function in particular

```rust
    fn http_post_uri_multipart_form<'a, 'p, RS, PT, TS>(
        &'a self,
        full_uri: Url,
        file: Option<FileMultipartData<'p>>,
        params: &'p PT,
        context: SlackClientApiCallContext<'a>,
    ) -> BoxFuture<'a, ClientResult<RS>>
```

`FileMultipartData` itself is declared public. However, it is inaccessible behind the private module. Another solution is to re-export it as public.