### PR TITLE
fix: Add `video` Slack block

### DIFF
--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -29,6 +29,8 @@ pub enum SlackBlock {
     Input(SlackInputBlock),
     #[serde(rename = "file")]
     File(SlackFileBlock),
+    #[serde(rename = "video")]
+    Video(SlackVideoBlock),
 
     // This block is still undocumented, so we don't define any structure yet we can return it back,
     #[serde(rename = "rich_text")]
@@ -997,5 +999,29 @@ impl From<&str> for SlackBlockPlainTextOnly {
         SlackBlockPlainTextOnly {
             value: value.into(),
         }
+    }
+}
+
+/**
+ * https://api.slack.com/reference/block-kit/blocks#video
+ */
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackVideoBlock {
+    pub alt_text: String,
+    pub author_name: Option<String>,
+    pub block_id: Option<SlackBlockId>,
+    pub description: Option<SlackBlockPlainTextOnly>,
+    pub provider_icon_url: Option<Url>,
+    pub provider_name: Option<String>,
+    pub title: SlackBlockPlainTextOnly,
+    pub title_url: Option<Url>,
+    pub thumbnail_url: Url,
+    pub video_url: Url,
+}
+
+impl From<SlackVideoBlock> for SlackBlock {
+    fn from(block: SlackVideoBlock) -> Self {
+        SlackBlock::Video(block)
     }
 }


### PR DESCRIPTION
This PR adds the support for the `video` Slack block documented [here](https://api.slack.com/reference/block-kit/blocks#video).