### PR TITLE
feat: Implement SlackTextFormat for SlackUserGroupId

### DIFF
--- a/src/models/common/mod.rs
+++ b/src/models/common/mod.rs
@@ -110,6 +110,12 @@ impl SlackTextFormat for SlackUserId {
     }
 }
 
+impl SlackTextFormat for SlackUserGroupId {
+    fn to_slack_format(&self) -> String {
+        format!("<!subteam^{}>", self.value())
+    }
+}
+
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Serialize, Deserialize, ValueStruct)]
 pub struct SlackBotId(pub String);
 


### PR DESCRIPTION
This PR implements `SlackTextFormat` for `SlackUserGroupId`. It returns the slack subteam format (e.g., `<!subteam^S12345>` that can be used to mention groups in messages. <https://api.slack.com/reference/surfaces/formatting#mentioning-groups>