### PR TITLE
fix: Fix `emoji_list` response deserialization

### DIFF
--- a/src/api/emoji.rs
+++ b/src/api/emoji.rs
@@ -36,3 +36,29 @@ where
 pub struct SlackApiEmojiListResponse {
     pub emoji: HashMap<SlackEmojiName, SlackEmojiRef>,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_slack_api_emoji_list_response() {
+        let payload = include_str!("./fixtures/slack_api_emoji_list_response.json");
+        let model: SlackApiEmojiListResponse = serde_json::from_str(payload).unwrap();
+
+        assert_eq!(model.emoji.len(), 1);
+        assert!(model
+            .emoji
+            .contains_key(&SlackEmojiName::new("test".to_string())));
+        let test_emoji = model
+            .emoji
+            .get(&SlackEmojiName::new("test".to_string()))
+            .unwrap();
+        match test_emoji {
+            SlackEmojiRef::Url(url) => {
+                assert_eq!(url.as_str(), "https://emoji.slack-edge.com/test_emoji.png")
+            }
+            _ => panic!("unexpected emoji type"),
+        }
+    }
+}

--- a/src/api/fixtures/slack_api_emoji_list_response.json
+++ b/src/api/fixtures/slack_api_emoji_list_response.json
@@ -1,0 +1,7 @@
+{
+    "ok": true,
+    "emoji": {
+        "test": "https:\/\/emoji.slack-edge.com\/test_emoji.png"
+    },
+    "cache_ts": "1742309006.064153"
+}


### PR DESCRIPTION
My initial implementation was actually buggy.
Indeed, Slack response to `emoji.list` contains URLs with escaped `/`.
Here is an example:
```json
{
    "ok": true,
    "emoji": {
        "test": "https:\/\/emoji.slack-edge.com\/test_emoji.png"
    },
    "cache_ts": "1742309006.064153"
}
```

The deserializer was thus unable to parse the URL and failed.