### PR TITLE
feat: add `share_shortcut` variant to SlackBlock enum

### DIFF
--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -37,6 +37,8 @@ pub enum SlackBlock {
     // This block is still undocumented, so we don't define any structure yet we can return it back,
     #[serde(rename = "rich_text")]
     RichText(serde_json::Value),
+    #[serde(rename = "share_shortcut")]
+    ShareShortcut(serde_json::Value),
     #[serde(rename = "event")]
     Event(serde_json::Value),
 }


### PR DESCRIPTION
# Problem
- When deserialising Slack events we rely on the Block enum, which is generated from the official Block Kit documentation.
- Slack might recently added sending the block type `share_shortcut`, which is not part of the documentation.

So `serde` therefore throws:
```markdown
json_error: Error("unknown variant `share_shortcut`, expected one of `section`, `header`, `divider`, `image`, `actions`, `context`, `input`, `file`, `video`, `markdown`, `rich_text`, `event`", line: 1, column: 18147)
```


# Fix
- Add a fallback arm that deserialises `share_shortcut` block into serde_json::Value.

## Follow-ups / long-term
- Consider marking the enum variant attributes with `#[serde(untagged)]`(https://serde.rs/variant-attrs.html#untagged)  to achieve forward compatibility across the board.

```rs
pub enum SlackBlock {
  // ... 
 #[serde(untagged)]
 Unknown
}