### PR TITLE
Add optional OAuth 2.0 `user_scope` to redirect url

### DIFF
--- a/src/axum_support/slack_oauth_routes.rs
+++ b/src/axum_support/slack_oauth_routes.rs
@@ -34,6 +34,7 @@ impl<H: 'static + Send + Sync + Connect + Clone> SlackEventsAxumListener<H> {
                     &vec![
                         ("client_id", Some(config.client_id.value())),
                         ("scope", Some(&config.bot_scope)),
+                        ("user_scope", Some(&config.user_scope)),
                         (
                             "redirect_uri",
                             Some(config.to_redirect_url()?.as_str().to_string()).as_ref(),

--- a/src/hyper_tokio/listener/oauth.rs
+++ b/src/hyper_tokio/listener/oauth.rs
@@ -26,6 +26,7 @@ impl<H: 'static + Send + Sync + Connect + Clone> SlackClientEventsHyperListener<
             &vec![
                 ("client_id", Some(config.client_id.value())),
                 ("scope", Some(&config.bot_scope)),
+                ("user_scope", Some(&config.user_scope)),
                 (
                     "redirect_uri",
                     Some(config.to_redirect_url()?.as_str().to_string()).as_ref(),

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -137,6 +137,7 @@ pub struct SlackOAuthListenerConfig {
     pub client_id: SlackClientId,
     pub client_secret: SlackClientSecret,
     pub bot_scope: String,
+    pub user_scope: String,
     pub redirect_callback_host: String,
     #[default = "SlackOAuthListenerConfig::DEFAULT_INSTALL_PATH_VALUE.into()"]
     pub install_path: String,


### PR DESCRIPTION
Adds missing `user_scope` URL parameter to `SlackOAuthListenerConfig`, present in the official [Slack API documentation](https://api.slack.com/authentication/oauth-v2)