### PR TITLE
fix(pins): items attribute should be public

### DIFF
--- a/src/api/pins.rs
+++ b/src/api/pins.rs
@@ -73,7 +73,7 @@ pub struct SlackApiPinsListRequest {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiPinsListResponse {
-    items: Vec<SlackPin>,
+    pub items: Vec<SlackPin>,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
### Description
#331 introduced the Pins API, but the attribute `items` was wrongly added as private (my bad).
This PR fixes that and makes so that we can access the items under `SlackApiPinsListResponse`.