### PR TITLE
feat(models): add missing message subtypes and Unknown catch-all to SlackMessageEventType

### DIFF
--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -168,6 +168,13 @@ pub enum SlackMessageEventType {
     ShareShortcut,
     #[serde(rename = "channel_canvas_updated")]
     ChannelCanvasUpdated,
+    #[serde(rename = "tabbed_canvas_updated")]
+    TabbedCanvasUpdated,
+    #[serde(rename = "channel_posting_permissions")]
+    ChannelPostingPermissions,
+    /// Catch-all for unknown subtypes Slack may add in the future.
+    #[serde(other)]
+    Unknown,
 }
 
 #[skip_serializing_none]

--- a/src/models/events/push.rs
+++ b/src/models/events/push.rs
@@ -173,8 +173,9 @@ pub enum SlackMessageEventType {
     #[serde(rename = "channel_posting_permissions")]
     ChannelPostingPermissions,
     /// Catch-all for unknown subtypes Slack may add in the future.
-    #[serde(other)]
-    Unknown,
+    /// Preserves the original subtype string.
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
Slack continues to introduce new message subtypes that aren't in the enum. When serde encounters an unknown variant, the entire event deserialization fails and an ERROR is logged, even though the event itself is harmless (the bot simply has nothing to do with it).

This PR:
- Adds `TabbedCanvasUpdated` and `ChannelPostingPermissions`, two recently observed subtypes in production
- Adds an `Unknown` catch-all variant with `#[serde(other)]` so future unknown subtypes are silently ignored rather than causing parse errors

**Observed in production logs:**
```
unknown variant `tabbed_canvas_updated`, expected one of `bot_message`, `me_message`, ...
unknown variant `channel_posting_permissions`, expected one of `bot_message`, `me_message`, ...
```