### PR TITLE
feat(models): add proper typing for rich text block and rich text input element

### DIFF
--- a/src/models/blocks/fixtures/slack_rich_text_block.json
+++ b/src/models/blocks/fixtures/slack_rich_text_block.json
@@ -1,0 +1,70 @@
+{
+  "type": "rich_text",
+  "block_id": "test_block",
+  "elements": [
+    {
+      "type": "rich_text_section",
+      "elements": [
+        {
+          "type": "text",
+          "text": "Hello ",
+          "style": { "bold": true }
+        },
+        {
+          "type": "user",
+          "user_id": "U123ABC456"
+        },
+        {
+          "type": "text",
+          "text": "! Check out "
+        },
+        {
+          "type": "link",
+          "url": "https://example.com",
+          "text": "this link",
+          "style": { "italic": true }
+        },
+        {
+          "type": "emoji",
+          "name": "wave"
+        },
+        {
+          "type": "channel",
+          "channel_id": "C123ABC456"
+        },
+        {
+          "type": "broadcast",
+          "range": "here"
+        }
+      ]
+    },
+    {
+      "type": "rich_text_list",
+      "style": "bullet",
+      "indent": 0,
+      "elements": [
+        {
+          "type": "rich_text_section",
+          "elements": [{ "type": "text", "text": "Item one" }]
+        },
+        {
+          "type": "rich_text_section",
+          "elements": [{ "type": "text", "text": "Item two" }]
+        }
+      ]
+    },
+    {
+      "type": "rich_text_preformatted",
+      "elements": [
+        { "type": "text", "text": "fn main() {}\n" }
+      ],
+      "border": 1
+    },
+    {
+      "type": "rich_text_quote",
+      "elements": [
+        { "type": "text", "text": "A wise quote", "style": { "italic": true } }
+      ]
+    }
+  ]
+}

--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -1215,14 +1215,14 @@ pub struct SlackRichTextUserGroup {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackRichTextEmoji {
-    pub name: String,
+    pub name: SlackEmojiName,
     pub unicode: Option<String>,
 }
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackRichTextDate {
-    pub timestamp: u64,
+    pub timestamp: i64,
     pub format: String,
     pub fallback: Option<String>,
     pub style: Option<SlackRichTextStyle>,
@@ -1417,6 +1417,71 @@ mod test {
             },
             _ => panic!("Expected a section block"),
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_rich_text_block_deserialize() -> Result<(), Box<dyn std::error::Error>> {
+        let payload = include_str!("./fixtures/slack_rich_text_block.json");
+        let block: SlackBlock = serde_json::from_str(payload)?;
+
+        let rich = match block {
+            SlackBlock::RichText(r) => r,
+            _ => panic!("Expected a RichText block"),
+        };
+
+        assert_eq!(rich.block_id, Some(SlackBlockId("test_block".into())));
+        assert_eq!(rich.elements.len(), 4);
+
+        // section
+        let section = match &rich.elements[0] {
+            SlackRichTextElement::Section(s) => s,
+            _ => panic!("Expected a Section element"),
+        };
+        assert_eq!(section.elements.len(), 7);
+
+        // bold text
+        let text = match &section.elements[0] {
+            SlackRichTextInlineElement::Text(t) => t,
+            _ => panic!("Expected a Text element"),
+        };
+        assert_eq!(text.text, "Hello ");
+        assert_eq!(text.style.as_ref().and_then(|s| s.bold), Some(true));
+
+        // user
+        assert!(matches!(&section.elements[1], SlackRichTextInlineElement::User(_)));
+
+        // emoji — name should deserialize as SlackEmojiName
+        let emoji = match &section.elements[4] {
+            SlackRichTextInlineElement::Emoji(e) => e,
+            _ => panic!("Expected an Emoji element"),
+        };
+        assert_eq!(emoji.name, SlackEmojiName::new("wave".into()));
+
+        // list
+        let list = match &rich.elements[1] {
+            SlackRichTextElement::List(l) => l,
+            _ => panic!("Expected a List element"),
+        };
+        assert_eq!(list.style, SlackRichTextListStyle::Bullet);
+        assert_eq!(list.elements.len(), 2);
+
+        // preformatted
+        assert!(matches!(&rich.elements[2], SlackRichTextElement::Preformatted(_)));
+
+        // quote
+        assert!(matches!(&rich.elements[3], SlackRichTextElement::Quote(_)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rich_text_block_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+        let payload = include_str!("./fixtures/slack_rich_text_block.json");
+        let block: SlackBlock = serde_json::from_str(payload)?;
+        let serialized = serde_json::to_string(&block)?;
+        let block2: SlackBlock = serde_json::from_str(&serialized)?;
+        assert_eq!(block, block2);
         Ok(())
     }
 }

--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -34,9 +34,8 @@ pub enum SlackBlock {
     #[serde(rename = "markdown")]
     Markdown(SlackMarkdownBlock),
 
-    // This block is still undocumented, so we don't define any structure yet we can return it back,
     #[serde(rename = "rich_text")]
-    RichText(serde_json::Value),
+    RichText(SlackRichTextBlock),
     #[serde(rename = "share_shortcut")]
     ShareShortcut(serde_json::Value),
     #[serde(rename = "event")]
@@ -291,6 +290,8 @@ pub enum SlackInputBlockElement {
     Checkboxes(SlackBlockCheckboxesElement),
     #[serde(rename = "email_text_input")]
     EmailInput(SlackBlockEmailInputElement),
+    #[serde(rename = "rich_text_input")]
+    RichTextInput(SlackBlockRichTextInputElement),
 }
 
 #[skip_serializing_none]
@@ -1067,6 +1068,202 @@ pub struct SlackMarkdownBlock {
 impl From<SlackMarkdownBlock> for SlackBlock {
     fn from(block: SlackMarkdownBlock) -> Self {
         SlackBlock::Markdown(block)
+    }
+}
+
+/**
+ * https://api.slack.com/reference/block-kit/blocks#rich_text
+ */
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextBlock {
+    pub block_id: Option<SlackBlockId>,
+    pub elements: Vec<SlackRichTextElement>,
+}
+
+impl From<SlackRichTextBlock> for SlackBlock {
+    fn from(block: SlackRichTextBlock) -> Self {
+        SlackBlock::RichText(block)
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum SlackRichTextElement {
+    #[serde(rename = "rich_text_section")]
+    Section(SlackRichTextSection),
+    #[serde(rename = "rich_text_list")]
+    List(SlackRichTextList),
+    #[serde(rename = "rich_text_preformatted")]
+    Preformatted(SlackRichTextPreformatted),
+    #[serde(rename = "rich_text_quote")]
+    Quote(SlackRichTextQuote),
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextSection {
+    pub elements: Vec<SlackRichTextInlineElement>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextList {
+    pub style: SlackRichTextListStyle,
+    pub elements: Vec<SlackRichTextSection>,
+    pub indent: Option<u64>,
+    pub offset: Option<u64>,
+    pub border: Option<u64>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlackRichTextListStyle {
+    Bullet,
+    Ordered,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextPreformatted {
+    pub elements: Vec<SlackRichTextInlineElement>,
+    pub border: Option<u64>,
+    pub language: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextQuote {
+    pub elements: Vec<SlackRichTextInlineElement>,
+    pub border: Option<u64>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum SlackRichTextInlineElement {
+    #[serde(rename = "text")]
+    Text(SlackRichTextText),
+    #[serde(rename = "link")]
+    Link(SlackRichTextLink),
+    #[serde(rename = "user")]
+    User(SlackRichTextUser),
+    #[serde(rename = "channel")]
+    Channel(SlackRichTextChannel),
+    #[serde(rename = "usergroup")]
+    UserGroup(SlackRichTextUserGroup),
+    #[serde(rename = "emoji")]
+    Emoji(SlackRichTextEmoji),
+    #[serde(rename = "date")]
+    Date(SlackRichTextDate),
+    #[serde(rename = "broadcast")]
+    Broadcast(SlackRichTextBroadcast),
+    #[serde(rename = "color")]
+    Color(SlackRichTextColor),
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextStyle {
+    pub bold: Option<bool>,
+    pub italic: Option<bool>,
+    pub strike: Option<bool>,
+    pub code: Option<bool>,
+    pub underline: Option<bool>,
+    pub highlight: Option<bool>,
+    pub client_highlight: Option<bool>,
+    pub unlink: Option<bool>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextText {
+    pub text: String,
+    pub style: Option<SlackRichTextStyle>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextLink {
+    pub url: String,
+    pub text: Option<String>,
+    #[serde(rename = "unsafe")]
+    pub unsafe_: Option<bool>,
+    pub style: Option<SlackRichTextStyle>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextUser {
+    pub user_id: SlackUserId,
+    pub style: Option<SlackRichTextStyle>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextChannel {
+    pub channel_id: SlackChannelId,
+    pub style: Option<SlackRichTextStyle>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextUserGroup {
+    pub usergroup_id: SlackUserGroupId,
+    pub style: Option<SlackRichTextStyle>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextEmoji {
+    pub name: String,
+    pub unicode: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextDate {
+    pub timestamp: u64,
+    pub format: String,
+    pub fallback: Option<String>,
+    pub style: Option<SlackRichTextStyle>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlackRichTextBroadcastRange {
+    Here,
+    Channel,
+    Everyone,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextBroadcast {
+    pub range: SlackRichTextBroadcastRange,
+    pub style: Option<SlackRichTextStyle>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackRichTextColor {
+    pub value: String,
+}
+
+/**
+ * https://api.slack.com/reference/block-kit/block-elements#rich_text_input
+ */
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackBlockRichTextInputElement {
+    pub action_id: SlackActionId,
+    pub initial_value: Option<SlackRichTextBlock>,
+    pub focus_on_load: Option<bool>,
+    pub placeholder: Option<SlackBlockPlainTextOnly>,
+}
+
+impl From<SlackBlockRichTextInputElement> for SlackInputBlockElement {
+    fn from(element: SlackBlockRichTextInputElement) -> Self {
+        SlackInputBlockElement::RichTextInput(element)
     }
 }
 

--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -1449,7 +1449,10 @@ mod test {
         assert_eq!(text.style.as_ref().and_then(|s| s.bold), Some(true));
 
         // user
-        assert!(matches!(&section.elements[1], SlackRichTextInlineElement::User(_)));
+        assert!(matches!(
+            &section.elements[1],
+            SlackRichTextInlineElement::User(_)
+        ));
 
         // emoji — name should deserialize as SlackEmojiName
         let emoji = match &section.elements[4] {
@@ -1467,7 +1470,10 @@ mod test {
         assert_eq!(list.elements.len(), 2);
 
         // preformatted
-        assert!(matches!(&rich.elements[2], SlackRichTextElement::Preformatted(_)));
+        assert!(matches!(
+            &rich.elements[2],
+            SlackRichTextElement::Preformatted(_)
+        ));
 
         // quote
         assert!(matches!(&rich.elements[3], SlackRichTextElement::Quote(_)));


### PR DESCRIPTION
Closes #321, closes #327

The `rich_text` block and `rich_text_input` element were previously untyped (`serde_json::Value`). Both are now fully documented in the Slack API, so this PR adds proper Rust types following the existing codebase patterns.

## Changes

### `SlackRichTextBlock` (replaces `serde_json::Value` placeholder)
- `SlackRichTextElement` enum: `Section`, `List`, `Preformatted`, `Quote`
- `SlackRichTextSection` — container for inline elements
- `SlackRichTextList` — bullet/ordered list with `indent`, `offset`, `border`
- `SlackRichTextPreformatted` — code block with optional `language`
- `SlackRichTextQuote` — block quote with optional `border`

### `SlackRichTextInlineElement` enum
`Text`, `Link`, `User`, `Channel`, `UserGroup`, `Emoji`, `Date`, `Broadcast`, `Color`

### `SlackRichTextStyle`
Shared style struct for inline elements: `bold`, `italic`, `strike`, `code`, `underline`, `highlight`, `client_highlight`, `unlink`

### `SlackBlockRichTextInputElement`
New input element wired into `SlackInputBlockElement::RichTextInput`. Fields: `action_id`, `initial_value`, `focus_on_load`, `placeholder`.

## References
- https://api.slack.com/reference/block-kit/blocks#rich_text
- https://api.slack.com/reference/block-kit/block-elements#rich_text_input