### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -3,6 +3,8 @@ on:
   push:
   pull_request:
     types: [ opened ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/abdolence/slack-morphism-rust/security/code-scanning/4](https://github.com/abdolence/slack-morphism-rust/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/windows-build.yml` so all jobs in this workflow get least-privilege token scope by default.  
For this workflow, the minimal required permission is:

- `contents: read` (needed for `actions/checkout` and reading repository content)

Best single fix without changing behavior: insert `permissions:` at workflow root (after `on:` block is a clean location), with `contents: read`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
