### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/abdolence/slack-morphism-rust/security/code-scanning/3](https://github.com/abdolence/slack-morphism-rust/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/tests.yml` at the workflow root (top level), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (checkout + local cargo commands) while restricting token scope. No imports, methods, or additional definitions are needed—just a YAML key addition between existing top-level sections (e.g., after `concurrency` and before `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
