### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/abdolence/slack-morphism-rust/security/code-scanning/2](https://github.com/abdolence/slack-morphism-rust/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is scoped minimally but still allows publishing to `gh-pages`.

Best single fix here: define workflow-level permissions directly under `on`/before `concurrency` in `.github/workflows/gh-pages.yml`:

- `contents: write` (required to push to `gh-pages`)
- `pages: write` is **not** required for `peaceiris/actions-gh-pages` push-based deploys, so omit it.
- Keep other permissions unset (defaults to none when permissions are explicitly defined), preserving least privilege.

This change does not alter workflow behavior besides making token scope explicit and constrained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
