### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -6,6 +6,8 @@ on:
       - '**/Cargo.lock'
   schedule:
     - cron: '5 4 * * 6'
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/abdolence/slack-morphism-rust/security/code-scanning/1](https://github.com/abdolence/slack-morphism-rust/security/code-scanning/1)

Add an explicit `permissions` block to this workflow so `GITHUB_TOKEN` is constrained to the minimum required scope.  
Best fix without changing functionality: define workflow-level permissions with `contents: read` right after the `on:` triggers (or before `jobs:`). This applies to all jobs in the workflow and preserves current behavior, since the workflow only needs to read repository content for checkout/audit.

**File to edit:** `.github/workflows/security-audit.yml`  
**Change:** insert:

```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
