### PR TITLE
Add Table variant to SlackBlock enum

### DIFF
--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -39,6 +39,8 @@ pub enum SlackBlock {
     ShareShortcut(serde_json::Value),
     #[serde(rename = "event")]
     Event(serde_json::Value),
+    #[serde(rename = "table")]
+    Table(serde_json::Value),
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
Fixes #360.

Slack's Block Kit includes a `table` block type not yet represented in `SlackBlock`. Any `conversations.history` response containing a table block currently fails to deserialize entirely.

This adds `Table(serde_json::Value)` using the same untyped-value pattern as the existing `ShareShortcut` and `Event` variants.

**Change:** one variant added to the `SlackBlock` enum in `src/models/blocks/kit.rs` — no other files touched.