### PR TITLE
Remove duplicate WSS pong reply

### DIFF
--- a/src/hyper_tokio/socket_mode/tungstenite_wss_client.rs
+++ b/src/hyper_tokio/socket_mode/tungstenite_wss_client.rs
@@ -37,7 +37,6 @@ where
 #[derive(Clone, Debug)]
 enum SlackTungsteniteWssClientCommand {
     Message(String),
-    Pong(Vec<u8>),
     Exit,
 }
 
@@ -245,21 +244,6 @@ where
                                         rx.close()
                                     }
                                 }
-                                SlackTungsteniteWssClientCommand::Pong(body) => {
-                                    trace!(
-                                        slack_wss_client_id = thread_identity.id.to_string().as_str(),
-                                        "[{}] Pong to Slack: {:?}",
-                                        thread_identity.id.to_string(),
-                                        body
-                                    );
-                                    if writer
-                                        .send(tokio_tungstenite::tungstenite::Message::Pong(body.into()))
-                                        .await
-                                        .is_err()
-                                    {
-                                        rx.close()
-                                    }
-                                }
                                 SlackTungsteniteWssClientCommand::Exit => {
                                     writer.close().await.unwrap_or(());
                                     rx.close();
@@ -376,8 +360,6 @@ where
                                 thread_identity.id.to_string(),
                                 &body
                             );
-                            tx.send(SlackTungsteniteWssClientCommand::Pong(body.into()))
-                                .unwrap_or(());
                         }
                         Ok(tokio_tungstenite::tungstenite::Message::Pong(body)) => {
                             trace!(

--- a/src/hyper_tokio/socket_mode/tungstenite_wss_client.rs
+++ b/src/hyper_tokio/socket_mode/tungstenite_wss_client.rs
@@ -322,7 +322,6 @@ where
 
         {
             let thread_identity = identity.clone();
-            let thread_last_time_pong_received = last_time_pong_received;
             let thread_destroyed = destroyed.clone();
 
             tokio::spawn(async move {
@@ -368,8 +367,6 @@ where
                                 thread_identity.id.to_string(),
                                 &body
                             );
-                            let mut last_pong = thread_last_time_pong_received.write().await;
-                            last_pong.time = SystemTime::now();
                         }
                         Ok(tokio_tungstenite::tungstenite::Message::Binary(body)) => {
                             warn!(


### PR DESCRIPTION
Currently all pings from Slack trigger two separate pong replies, because Tungstenite (`tokio-tungstenite`) [already handles replying to pings](https://github.com/snapview/tokio-tungstenite/issues/88#issuecomment-588133379).

This removes the manual sending of a pong when a ping is received, and also the definition and usage of `SlackTungsteniteWssClientCommand::Pong` since it's no longer ever constructed.
I left the trace logs in, in case they're of interest. Happy to remove them and update the PR if you'd prefer.

-----

To verify this behaviour you can set the max log level to trace (`log::set_max_level(LevelFilter::Trace)`, not sure what the equivalent for the `tracing` crate is sorry) and start listening on a slack socket.

Without this PR you will see two `writing frame [...] opcode: PONG` log entries for each ping received from Slack on a given socket.
With this PR there's only one for each ping on a given socket.