### PR TITLE
fix: Restore pong received timestamp in WSS client

### DIFF
--- a/src/hyper_tokio/socket_mode/tungstenite_wss_client.rs
+++ b/src/hyper_tokio/socket_mode/tungstenite_wss_client.rs
@@ -322,6 +322,7 @@ where
 
         {
             let thread_identity = identity.clone();
+            let thread_last_time_pong_received = last_time_pong_received;
             let thread_destroyed = destroyed.clone();
 
             tokio::spawn(async move {
@@ -367,6 +368,8 @@ where
                                 thread_identity.id.to_string(),
                                 &body
                             );
+                            let mut last_pong = thread_last_time_pong_received.write().await;
+                            last_pong.time = SystemTime::now();
                         }
                         Ok(tokio_tungstenite::tungstenite::Message::Binary(body)) => {
                             warn!(


### PR DESCRIPTION
PR #373 removed the duplicate pong reply, but it also dropped the `last_time_pong_received` write in the `Message::Pong` arm, which the watchdog on the ping side still reads. With no writer, the timestamp stays frozen at connection time, so every socket mode connection logs "Haven't seen any pong from Slack since N seconds ago" once ping_interval_in_seconds * ping_failure_threshold_times elapses (90s by default) and then disconnects and reconnects forever.