### PR TITLE
fix: add missing tokio macros feature (#377)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,5 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
       - run: cargo fmt -- --check && cargo clippy --all-features -- -Dwarnings && cargo test --all-features
+      - run: cargo check --no-default-features --features hyper
+      - run: cargo check --no-default-features --features axum

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ url = { version = "2.5", features = ["serde"] }
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.3", features = ["http2", "server", "client"], default-features = false, optional = true }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "server", "tokio"], default-features = false, optional = true }
-tokio = { version = "1", features = ["bytes", "rt-multi-thread", "signal", "tracing"], default-features = false, optional = true }
+tokio = { version = "1", features = ["bytes", "macros", "rt-multi-thread", "signal", "tracing"], default-features = false, optional = true }
 tokio-stream = { version = "0.1", optional = true }
 hyper-rustls = { version = "0.27", features = ["http2", "native-tokio"], default-features = false, optional = true }
 tokio-tungstenite = { version = "0.30.0", features = [], optional = true }


### PR DESCRIPTION
Fixes #377.

`tungstenite_wss_client.rs` uses `tokio::select!`, but the tokio dependency did not enable the `macros` feature. Crates depending on slack-morphism with only the `hyper` feature failed with `error[E0433]: cannot find select in tokio` unless another dependency enabled `macros` through feature unification.

Repro before the fix:

```
cargo new x && cd x
cargo add slack-morphism --no-default-features --features hyper
cargo check
```

Changes:
- add `macros` to the tokio feature list
- add `cargo check --no-default-features --features hyper|axum` to CI; the existing `--all-features` jobs build dev-dependencies (tokio `full`), which masked the problem