### PR TITLE
feat: migrate from chrono to jiff behind time type aliases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - run: cargo fmt -- --check && cargo clippy --all-features -- -Dwarnings && cargo test --all-features
+      - run: cargo fmt -- --check
+      - run: cargo clippy --features hyper,axum -- -Dwarnings && cargo test --features hyper,axum
+      - run: cargo clippy --all-features -- -Dwarnings && cargo test --all-features
       - run: cargo check --no-default-features --features hyper
       - run: cargo check --no-default-features --features axum

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -19,4 +19,6 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - run: cargo fmt -- --check && cargo clippy --all-features -- -Dwarnings && cargo test --all-features
+      - run: cargo fmt -- --check
+      - run: cargo clippy --features hyper,axum -- -Dwarnings && cargo test --features hyper,axum
+      - run: cargo clippy --all-features -- -Dwarnings && cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ axum-base = ["hyper-base", "dep:axum", "dep:tower"]
 rustls-native-certs = ["tokio-tungstenite/rustls-native-certs", "tokio-tungstenite/rustls-tls-native-roots", "hyper-rustls/rustls-native-certs", "hyper-rustls/ring"]
 hyper = ["hyper-base", "rustls-native-certs"]
 axum = ["axum-base", "hyper-base", "rustls-native-certs"]
+obsolete-chrono = ["dep:chrono"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], default-features = false }
@@ -49,7 +50,8 @@ rand = "0.10"
 async-recursion = "1.0"
 mime = "0.3"
 mime_guess = "2"
-chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
+jiff = { version = "0.2", default-features = false, features = ["std", "serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"], optional = true }
 url = { version = "2.5", features = ["serde"] }
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.3", features = ["http2", "server", "client"], default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ SLACK_SIGNING_SECRET=<your-signing-secret> \
 cargo run --example events_api_server  --all-features
 ```
 
+## Date and time types
+
+Dates and times in the models are exposed through the type aliases `SlackUtcDateTime` and
+`SlackCivilDate`, which are backed by [jiff](https://github.com/BurntSushi/jiff)
+(`jiff::Timestamp` and `jiff::civil::Date`).
+
+The deprecated `obsolete-chrono` feature switches both aliases back to the chrono types used
+before (`chrono::DateTime<chrono::Utc>` and `chrono::NaiveDate`) for an easier migration.
+Note that this feature is not additive: enabling it anywhere in a dependency graph changes the
+types for every crate in that graph, so it is intended as a temporary migration aid only.
+
 ## Licence
 Apache Software License (ASL)
 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -20,6 +20,10 @@ Includes also all type/models definitions that used for Slack Web/Events APIs.
 This library provided the following features:
 - `hyper`: Slack client support/binding for Hyper/Tokio/Tungstenite.
 - `axum`:  Slack client support/binding for [axum framework](https://github.com/tokio-rs/axum) support.
+- `obsolete-chrono`: deprecated. Switches the `SlackUtcDateTime`/`SlackCivilDate` type aliases from
+  jiff back to the chrono types the library used before (`chrono::DateTime<chrono::Utc>` and
+  `chrono::NaiveDate`). This feature is not additive: enabling it anywhere in a dependency graph
+  changes the types for the whole graph, so it is intended as a temporary migration aid only.
 
 ### TLS-related configuration features
 By default, `hyper` and `axum` features use `rustls-native-certs` and `hyper-rustls/ring` setup for TLS configuration, 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -20,10 +20,7 @@ Includes also all type/models definitions that used for Slack Web/Events APIs.
 This library provided the following features:
 - `hyper`: Slack client support/binding for Hyper/Tokio/Tungstenite.
 - `axum`:  Slack client support/binding for [axum framework](https://github.com/tokio-rs/axum) support.
-- `obsolete-chrono`: deprecated. Switches the `SlackUtcDateTime`/`SlackCivilDate` type aliases from
-  jiff back to the chrono types the library used before (`chrono::DateTime<chrono::Utc>` and
-  `chrono::NaiveDate`). This feature is not additive: enabling it anywhere in a dependency graph
-  changes the types for the whole graph, so it is intended as a temporary migration aid only.
+- `obsolete-chrono`: deprecated. Keeps the date/time types backed by `chrono` instead of `jiff` to ease migration.
 
 ### TLS-related configuration features
 By default, `hyper` and `axum` features use `rustls-native-certs` and `hyper-rustls/ring` setup for TLS configuration, 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,4 +1,3 @@
-use chrono::prelude::*;
 use slack_morphism::prelude::*;
 
 use rsb_derive::Builder;
@@ -162,7 +161,7 @@ impl SlackMessageTemplate for WelcomeMessageTemplateParams {
                     some(md!(
                         "Current time is: {}",
                         fmt_slack_date(
-                            &Local::now(),
+                            &SlackDateTime::now().0,
                             SlackDateTimeFormats::DatePretty.to_string().as_str(),
                             None
                         )
@@ -192,7 +191,7 @@ impl SlackMessageTemplate for WelcomeMessageTemplateParams {
 pub struct SlackHomeNewsItem {
     pub title: String,
     pub body: String,
-    pub published: DateTime<Utc>,
+    pub published: SlackUtcDateTime,
 }
 
 #[derive(Debug, Clone, Builder)]
@@ -213,7 +212,7 @@ impl SlackBlocksTemplate for SlackHomeTabBlocksTemplateExample {
                 some(md!(
                     "Current time is: {}",
                     fmt_slack_date(
-                        &Local::now(),
+                        &SlackDateTime::now().0,
                         SlackDateTimeFormats::DatePretty.to_string().as_str(),
                         None
                     )

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -161,7 +161,7 @@ impl SlackMessageTemplate for WelcomeMessageTemplateParams {
                     some(md!(
                         "Current time is: {}",
                         fmt_slack_date(
-                            &SlackDateTime::now().0,
+                            SlackDateTime::now().value(),
                             SlackDateTimeFormats::DatePretty.to_string().as_str(),
                             None
                         )
@@ -212,7 +212,7 @@ impl SlackBlocksTemplate for SlackHomeTabBlocksTemplateExample {
                 some(md!(
                     "Current time is: {}",
                     fmt_slack_date(
-                        &SlackDateTime::now().0,
+                        SlackDateTime::now().value(),
                         SlackDateTimeFormats::DatePretty.to_string().as_str(),
                         None
                     )

--- a/examples/socket_mode.rs
+++ b/examples/socket_mode.rs
@@ -1,4 +1,3 @@
-use chrono::prelude::*;
 use rsb_derive::Builder;
 use slack_morphism::prelude::*;
 use std::sync::Arc;
@@ -142,11 +141,11 @@ async fn test_push_events_sm_function(
                         SlackHomeNewsItem::new(
                         "Google claimed quantum supremacy in 2019 — and sparked controversy".into(),
                         "In October, researchers from Google claimed to have achieved a milestone known as quantum supremacy. They had created the first quantum computer that could perform a calculation that is impossible for a standard computer.".into(),
-                        DateTime::parse_from_rfc3339("2019-12-16T12:00:09Z").unwrap().into()),
+                        "2019-12-16T12:00:09Z".parse::<SlackUtcDateTime>().unwrap()),
                         SlackHomeNewsItem::new(
                             "Quantum jitter lets heat travel across a vacuum".into(),
                             "A new experiment shows that quantum fluctuations permit heat to bridge empty space.".into(),
-                            DateTime::parse_from_rfc3339("2019-12-16T12:00:09Z").unwrap().into())
+                            "2019-12-16T12:00:09Z".parse::<SlackUtcDateTime>().unwrap())
                     ],
                     home_event.user.clone(),
                 );
@@ -166,7 +165,7 @@ async fn test_push_events_sm_function(
 pub struct SlackHomeNewsItem {
     pub title: String,
     pub body: String,
-    pub published: DateTime<Utc>,
+    pub published: SlackUtcDateTime,
 }
 
 #[derive(Debug, Clone, Builder)]

--- a/src/models/blocks/datetime.rs
+++ b/src/models/blocks/datetime.rs
@@ -1,5 +1,4 @@
 use crate::SlackTextFormat;
-use chrono::prelude::*;
 
 pub enum SlackDateTimeFormats {
     DateNum,
@@ -30,28 +29,59 @@ impl ToString for SlackDateTimeFormats {
     }
 }
 
-pub fn fmt_slack_date<TZ: TimeZone>(
-    date: &DateTime<TZ>,
+fn fmt_slack_date_parts(
+    timestamp: i64,
+    fallback: &str,
     token_string: &str,
     link: Option<&String>,
-) -> String
-where
-    <TZ as chrono::offset::TimeZone>::Offset: std::fmt::Display,
-{
+) -> String {
     let link_part = link
         .map(|value| format!("^{value}"))
         .unwrap_or_else(|| "".into());
-    let fallback = date.to_rfc2822();
     format!(
         "<!date^{timestamp}^{token_string}{link_part}|{fallback}>",
-        timestamp = date.timestamp(),
+        timestamp = timestamp,
         token_string = token_string,
         link_part = link_part,
         fallback = fallback
     )
 }
 
-impl<TZ: TimeZone> SlackTextFormat for DateTime<TZ>
+#[cfg(not(feature = "obsolete-chrono"))]
+pub fn fmt_slack_date(
+    date: &crate::SlackUtcDateTime,
+    token_string: &str,
+    link: Option<&String>,
+) -> String {
+    use crate::models::common::datetime::{to_rfc2822, unix_seconds};
+
+    fmt_slack_date_parts(
+        unix_seconds(date),
+        to_rfc2822(date).as_str(),
+        token_string,
+        link,
+    )
+}
+
+#[cfg(feature = "obsolete-chrono")]
+pub fn fmt_slack_date<TZ: chrono::TimeZone>(
+    date: &chrono::DateTime<TZ>,
+    token_string: &str,
+    link: Option<&String>,
+) -> String
+where
+    <TZ as chrono::offset::TimeZone>::Offset: std::fmt::Display,
+{
+    fmt_slack_date_parts(
+        date.timestamp(),
+        date.to_rfc2822().as_str(),
+        token_string,
+        link,
+    )
+}
+
+#[cfg(feature = "obsolete-chrono")]
+impl<TZ: chrono::TimeZone> SlackTextFormat for chrono::DateTime<TZ>
 where
     <TZ as chrono::offset::TimeZone>::Offset: std::fmt::Display,
 {
@@ -61,5 +91,67 @@ where
             SlackDateTimeFormats::DatePretty.to_string().as_str(),
             None,
         )
+    }
+}
+
+#[cfg(not(feature = "obsolete-chrono"))]
+impl SlackTextFormat for jiff::Timestamp {
+    fn to_slack_format(&self) -> String {
+        fmt_slack_date(
+            self,
+            SlackDateTimeFormats::DatePretty.to_string().as_str(),
+            None,
+        )
+    }
+}
+
+#[cfg(not(feature = "obsolete-chrono"))]
+impl SlackTextFormat for jiff::Zoned {
+    fn to_slack_format(&self) -> String {
+        let fallback = jiff::fmt::rfc2822::to_string(self).unwrap_or_else(|_| self.to_string());
+        fmt_slack_date_parts(
+            self.timestamp().as_second(),
+            fallback.as_str(),
+            SlackDateTimeFormats::DatePretty.to_string().as_str(),
+            None,
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::prelude::SlackUtcDateTime;
+
+    /// Both the jiff and the chrono backend render RFC 2822 identically here,
+    /// so the expected fallback is the same in both feature modes.
+    const EXPECTED_FALLBACK: &str = "Wed, 1 Jan 2020 00:42:42 +0000";
+
+    #[test]
+    fn test_fmt_slack_date() {
+        let dt = "2020-01-01T00:42:42Z".parse::<SlackUtcDateTime>().unwrap();
+
+        assert_eq!(
+            fmt_slack_date(
+                &dt,
+                SlackDateTimeFormats::DatePretty.to_string().as_str(),
+                None
+            ),
+            format!("<!date^1577839362^{{date_pretty}}|{EXPECTED_FALLBACK}>")
+        );
+    }
+
+    #[test]
+    fn test_fmt_slack_date_with_link() {
+        let dt = "2020-01-01T00:42:42Z".parse::<SlackUtcDateTime>().unwrap();
+
+        assert_eq!(
+            fmt_slack_date(
+                &dt,
+                SlackDateTimeFormats::DateNum.to_string().as_str(),
+                Some(&"https://example.net/".to_string())
+            ),
+            format!("<!date^1577839362^{{date_num}}^https://example.net/|{EXPECTED_FALLBACK}>")
+        );
     }
 }

--- a/src/models/common/datetime.rs
+++ b/src/models/common/datetime.rs
@@ -1,0 +1,136 @@
+//! Date and time types used across the Slack models.
+//!
+//! The concrete time crate is hidden behind [`SlackUtcDateTime`] and [`SlackCivilDate`].
+//! By default they are backed by [`jiff`]. Enabling the deprecated `obsolete-chrono`
+//! feature switches them back to the `chrono` types the crate used before.
+//!
+//! This module is the only place in the crate that refers to a time crate directly.
+
+/// An instant in time in UTC, as used by the Slack API.
+///
+/// `jiff::Timestamp` by default, `chrono::DateTime<chrono::Utc>` with the
+/// deprecated `obsolete-chrono` feature.
+#[cfg(not(feature = "obsolete-chrono"))]
+pub type SlackUtcDateTime = jiff::Timestamp;
+
+/// An instant in time in UTC, as used by the Slack API.
+///
+/// `jiff::Timestamp` by default, `chrono::DateTime<chrono::Utc>` with the
+/// deprecated `obsolete-chrono` feature.
+#[cfg(feature = "obsolete-chrono")]
+pub type SlackUtcDateTime = chrono::DateTime<chrono::Utc>;
+
+/// A calendar date without a time zone, as used by the Slack API.
+///
+/// `jiff::civil::Date` by default, `chrono::NaiveDate` with the deprecated
+/// `obsolete-chrono` feature.
+#[cfg(not(feature = "obsolete-chrono"))]
+pub type SlackCivilDate = jiff::civil::Date;
+
+/// A calendar date without a time zone, as used by the Slack API.
+///
+/// `jiff::civil::Date` by default, `chrono::NaiveDate` with the deprecated
+/// `obsolete-chrono` feature.
+#[cfg(feature = "obsolete-chrono")]
+pub type SlackCivilDate = chrono::NaiveDate;
+
+/// Serde adapter for Slack's integer unix-seconds fields.
+///
+/// Used as `#[serde(with = "unix_seconds")]` on a [`SlackUtcDateTime`] field.
+pub(crate) mod unix_seconds {
+    #[cfg(not(feature = "obsolete-chrono"))]
+    pub use jiff::fmt::serde::timestamp::second::required::{deserialize, serialize};
+
+    #[cfg(feature = "obsolete-chrono")]
+    pub use chrono::serde::ts_seconds::{deserialize, serialize};
+}
+
+/// The current instant in UTC.
+pub(crate) fn now() -> SlackUtcDateTime {
+    #[cfg(not(feature = "obsolete-chrono"))]
+    {
+        jiff::Timestamp::now()
+    }
+    #[cfg(feature = "obsolete-chrono")]
+    {
+        chrono::Utc::now()
+    }
+}
+
+/// Builds an instant from unix seconds and an additional microseconds offset.
+///
+/// Returns `None` when the resulting instant is out of the supported range.
+pub(crate) fn from_unix_seconds_micros(secs: i64, micros: u32) -> Option<SlackUtcDateTime> {
+    let nanos = i32::try_from(micros).ok()?.checked_mul(1_000)?;
+
+    #[cfg(not(feature = "obsolete-chrono"))]
+    {
+        jiff::Timestamp::new(secs, nanos).ok()
+    }
+    #[cfg(feature = "obsolete-chrono")]
+    {
+        use chrono::TimeZone;
+        match chrono::Utc.timestamp_opt(secs, u32::try_from(nanos).ok()?) {
+            chrono::LocalResult::None => None,
+            chrono::LocalResult::Single(result) => Some(result),
+            chrono::LocalResult::Ambiguous(first, _) => Some(first),
+        }
+    }
+}
+
+/// The number of whole seconds since the unix epoch.
+// Only the jiff path of `fmt_slack_date` calls this: the chrono path keeps its generic
+// `DateTime<TZ>` signature and uses chrono's own inherent methods. Still exercised by tests
+// in both modes, so it is kept rather than gated out.
+#[cfg_attr(feature = "obsolete-chrono", allow(dead_code))]
+pub(crate) fn unix_seconds(date_time: &SlackUtcDateTime) -> i64 {
+    #[cfg(not(feature = "obsolete-chrono"))]
+    {
+        date_time.as_second()
+    }
+    #[cfg(feature = "obsolete-chrono")]
+    {
+        date_time.timestamp()
+    }
+}
+
+/// Formats an instant as an RFC 2822 date-time in UTC.
+// See the note on `unix_seconds` for why this is allowed to be unused under `obsolete-chrono`.
+#[cfg_attr(feature = "obsolete-chrono", allow(dead_code))]
+pub(crate) fn to_rfc2822(date_time: &SlackUtcDateTime) -> String {
+    #[cfg(not(feature = "obsolete-chrono"))]
+    {
+        jiff::fmt::rfc2822::to_string(&date_time.to_zoned(jiff::tz::TimeZone::UTC))
+            .unwrap_or_else(|_| date_time.to_string())
+    }
+    #[cfg(feature = "obsolete-chrono")]
+    {
+        date_time.to_rfc2822()
+    }
+}
+
+/// Parses a `YYYY-MM-DD` calendar date, rejecting anything else.
+pub(crate) fn parse_civil_date(value: &str) -> Option<SlackCivilDate> {
+    #[cfg(not(feature = "obsolete-chrono"))]
+    {
+        jiff::fmt::strtime::parse("%Y-%m-%d", value)
+            .and_then(|parsed| parsed.to_date())
+            .ok()
+    }
+    #[cfg(feature = "obsolete-chrono")]
+    {
+        SlackCivilDate::parse_from_str(value, "%Y-%m-%d").ok()
+    }
+}
+
+/// The current number of whole seconds since the unix epoch, read from the system clock.
+///
+/// Deliberately built on `std` only: the places that need a coarse wall clock reading
+/// (multipart boundaries, signature freshness) should not pull in a date/time crate.
+#[cfg(feature = "signature-verifier")]
+pub(crate) fn current_unix_seconds() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or_default()
+}

--- a/src/models/common/mod.rs
+++ b/src/models/common/mod.rs
@@ -1,5 +1,3 @@
-use chrono::serde::ts_seconds;
-use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use rsb_derive::Builder;
 use rvstruct::ValueStruct;
 use serde::{Deserialize, Serialize};
@@ -7,6 +5,12 @@ use serde_with::{serde_as, skip_serializing_none};
 use std::hash::Hash;
 use std::*;
 use url::Url;
+
+pub(crate) mod datetime;
+
+pub use datetime::*;
+
+use datetime::unix_seconds;
 
 mod user;
 
@@ -54,17 +58,31 @@ pub use assistant::*;
 pub struct SlackTs(pub String);
 
 impl SlackTs {
-    pub fn to_date_time_opt(&self) -> Option<DateTime<Utc>> {
-        let parts: Vec<&str> = self.value().split('.').collect();
-        if let Ok(ts_int) = parts[0].parse::<i64>() {
-            match Utc.timestamp_millis_opt(ts_int * 1000) {
-                chrono::LocalResult::None => None,
-                chrono::LocalResult::Single(result) => Some(result),
-                chrono::LocalResult::Ambiguous(first, _) => Some(first),
+    /// Converts a Slack timestamp (`<seconds>.<microseconds>`) to an instant.
+    ///
+    /// The fractional part is optional and is interpreted as microseconds,
+    /// padded or truncated to six digits.
+    pub fn to_date_time_opt(&self) -> Option<SlackUtcDateTime> {
+        let value = self.value();
+        let (seconds_part, micros_part) = match value.split_once('.') {
+            Some((seconds, micros)) => (seconds, Some(micros)),
+            None => (value.as_str(), None),
+        };
+
+        let seconds: i64 = seconds_part.parse().ok()?;
+
+        let micros: u32 = match micros_part {
+            Some(micros_part) => {
+                let mut digits: String = micros_part.chars().take(6).collect();
+                while digits.len() < 6 {
+                    digits.push('0');
+                }
+                digits.parse().ok()?
             }
-        } else {
-            None
-        }
+            None => 0,
+        };
+
+        datetime::from_unix_seconds_micros(seconds, micros)
     }
 }
 
@@ -126,11 +144,11 @@ impl SlackTextFormat for SlackUserGroupId {
 pub struct SlackBotId(pub String);
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, ValueStruct)]
-pub struct SlackDateTime(#[serde(with = "ts_seconds")] pub DateTime<Utc>);
+pub struct SlackDateTime(#[serde(with = "unix_seconds")] pub SlackUtcDateTime);
 
 impl SlackDateTime {
     pub fn now() -> Self {
-        Self(Utc::now())
+        Self(datetime::now())
     }
 }
 
@@ -138,8 +156,8 @@ impl SlackDateTime {
 pub struct SlackDate(pub String);
 
 impl SlackDate {
-    pub fn to_naive_date(&self) -> Option<NaiveDate> {
-        NaiveDate::parse_from_str(self.value(), "%Y-%m-%d").ok()
+    pub fn to_naive_date(&self) -> Option<SlackCivilDate> {
+        datetime::parse_civil_date(self.value())
     }
 }
 
@@ -323,15 +341,56 @@ impl From<&Url> for SlackRelaxedUrl {
 #[cfg(test)]
 mod test {
     use super::*;
+    use serde_json::json;
+
+    fn test_date_time() -> SlackUtcDateTime {
+        "2020-01-01T00:42:42Z".parse::<SlackUtcDateTime>().unwrap()
+    }
 
     #[test]
     fn test_slack_date_time() {
-        let dt = SlackDateTime(
-            DateTime::parse_from_rfc3339("2020-01-01T00:42:42Z")
-                .unwrap()
-                .into(),
-        );
+        let dt = SlackDateTime(test_date_time());
         let json = serde_json::to_value(&dt).unwrap();
         assert_eq!(json.as_u64().unwrap(), 1577839362);
+
+        let parsed: SlackDateTime = serde_json::from_value(json!(1577839362)).unwrap();
+        assert_eq!(parsed, dt);
+        assert_eq!(serde_json::from_value::<SlackDateTime>(json).unwrap(), dt);
+    }
+
+    #[test]
+    fn test_slack_ts_to_date_time_with_micros() {
+        let ts = SlackTs("1577839362.000400".to_string());
+        let dt = ts.to_date_time_opt().unwrap();
+
+        assert_eq!(datetime::unix_seconds(&dt), 1577839362);
+        assert_eq!(
+            Some(dt),
+            datetime::from_unix_seconds_micros(1577839362, 400)
+        );
+        assert_ne!(Some(dt), datetime::from_unix_seconds_micros(1577839362, 0));
+    }
+
+    #[test]
+    fn test_slack_ts_to_date_time_without_fraction() {
+        let ts = SlackTs("1577839362".to_string());
+        let dt = ts.to_date_time_opt().unwrap();
+
+        assert_eq!(datetime::unix_seconds(&dt), 1577839362);
+        assert_eq!(Some(dt), datetime::from_unix_seconds_micros(1577839362, 0));
+    }
+
+    #[test]
+    fn test_slack_ts_to_date_time_invalid() {
+        assert_eq!(SlackTs("garbage".to_string()).to_date_time_opt(), None);
+    }
+
+    #[test]
+    fn test_slack_date_to_naive_date() {
+        assert!(SlackDate("2020-01-01".to_string())
+            .to_naive_date()
+            .is_some());
+        assert_eq!(SlackDate("2020-13-01".to_string()).to_naive_date(), None);
+        assert_eq!(SlackDate("garbage".to_string()).to_naive_date(), None);
     }
 }

--- a/src/multipart_form.rs
+++ b/src/multipart_form.rs
@@ -12,7 +12,7 @@ pub struct FileMultipartData<'a> {
 pub fn generate_multipart_boundary() -> String {
     format!(
         "----WebKitFormBoundarySlackMorphismRust{}",
-        chrono::Utc::now().timestamp()
+        crate::current_unix_seconds()
     )
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,3 +16,5 @@ pub use crate::hyper_tokio::*;
 
 #[cfg(feature = "axum-base")]
 pub use crate::axum_support::*;
+
+pub use rvstruct::ValueStruct; // .value() / .into_value() on every Slack newtype

--- a/src/signature_verifier.rs
+++ b/src/signature_verifier.rs
@@ -33,7 +33,7 @@ impl SlackEventSignatureVerifier {
         body: &'b str,
         ts: &'b str,
     ) -> Result<(), SlackEventSignatureVerifierError> {
-        self.verify_at_time(hash, body, ts, chrono::Utc::now().timestamp())
+        self.verify_at_time(hash, body, ts, crate::current_unix_seconds())
     }
 
     fn verify_at_time<'b>(
@@ -223,6 +223,7 @@ impl Error for SlackEventTimestampError {}
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::current_unix_seconds;
 
     #[test]
     fn check_signature_success() {
@@ -233,7 +234,7 @@ mod test {
         let verifier = SlackEventSignatureVerifier::new(&key_str.into());
 
         const TEST_BODY: &str = "test-body";
-        let test_ts = chrono::Utc::now().timestamp().to_string();
+        let test_ts = current_unix_seconds().to_string();
 
         let hash = verifier.sign(TEST_BODY, &test_ts).unwrap();
         verifier
@@ -282,7 +283,7 @@ mod test {
         let verifier_malicious = SlackEventSignatureVerifier::new(&key_str_malicious.into());
 
         const TEST_BODY: &str = "test-body";
-        let test_ts = chrono::Utc::now().timestamp().to_string();
+        let test_ts = current_unix_seconds().to_string();
 
         let hash = verifier_malicious.sign(TEST_BODY, &test_ts).unwrap();
         let err = verifier_correct
@@ -304,7 +305,7 @@ mod test {
 
         const TEST_BODY: &str = "test-body";
 
-        let test_ts = (chrono::Utc::now().timestamp() - 10 * 60 * 1000).to_string();
+        let test_ts = (current_unix_seconds() - 10 * 60 * 1000).to_string();
         let hash = verifier.sign(TEST_BODY, &test_ts).unwrap();
 
         match verifier.verify(&hash, TEST_BODY, &test_ts).unwrap_err() {


### PR DESCRIPTION
chrono is soft-deprecated, so the crate now uses jiff by default and hides the time crate behind the SlackUtcDateTime and SlackCivilDate type aliases, which keeps any future swap a one-module change. The deprecated obsolete-chrono feature switches both aliases back to chrono::DateTime<chrono::Utc> and chrono::NaiveDate for an easier migration, but it is not additive: enabling it anywhere in a dependency graph changes the types for the whole graph. The default return types of SlackTs::to_date_time_opt, SlackDate::to_naive_date and SlackDateTime change; SlackTs::to_date_time_opt also now keeps the microseconds it used to drop.