### PR TITLE
feat: one interaction response type for block_suggestion replies (#254)

### DIFF
--- a/docs/src/events-api-axum.md
+++ b/docs/src/events-api-axum.md
@@ -48,11 +48,26 @@ async fn test_command_event(
     ))
 }
 
+// `SlackInteractionResponse` implements `axum::response::IntoResponse`, so one handler
+// can answer every kind of interaction: options for `block_suggestion`, a
+// `response_action` for `view_submission`, and an empty 200 for everything else.
 async fn test_interaction_event(
     Extension(_environment): Extension<Arc<SlackHyperListenerEnvironment>>,
     Extension(event): Extension<SlackInteractionEvent>,
-) {
+) -> SlackInteractionResponse {
     println!("Received interaction event: {:?}", event);
+
+    match event {
+        SlackInteractionEvent::BlockSuggestion(suggestion_event) => {
+            // `suggestion_event.value` is what the user has typed so far.
+            // Slack allows at most 100 plain text options here.
+            SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(vec![
+                SlackBlockChoiceItem::new(pt!("Unexpected sentience"), "AI-2323".to_string()),
+            ]))
+            .into()
+        }
+        _ => SlackInteractionResponse::Empty,
+    }
 }
 
 fn test_error_handler(
@@ -130,3 +145,7 @@ async fn test_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 ``` 
 Complete example look at [github](https://github.com/abdolence/slack-morphism-rust/tree/master/examples)
+
+To serve the Options Load URL for `external_select` menus, point it at the same
+`/interaction` route: the `block_suggestion` payload arrives through the same extractor.
+See [Events API for Hyper](events-api-hyper.md) for the limits Slack applies to the reply.

--- a/docs/src/events-api-hyper.md
+++ b/docs/src/events-api-hyper.md
@@ -81,14 +81,17 @@ async fn create_slack_events_listener_server() -> Result<(), Box<dyn std::error:
         Ok(())
     }
 
-    // Interaction events handler
+    // Interaction events handler.
+    // Returning `SlackInteractionResponse` lets one handler answer every kind of
+    // interaction: options for `block_suggestion`, a `response_action` for
+    // `view_submission`, and a plain acknowledgement for everything else.
     async fn slack_interaction_events_function(event: SlackInteractionEvent, 
         _client: Arc<SlackHyperClient>,
         _states: SlackClientEventsUserState
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<SlackInteractionResponse, Box<dyn std::error::Error + Send + Sync>> {
         println!("{:#?}", event);
 
-        Ok(())
+        Ok(SlackInteractionResponse::Empty)
     }
 
     // Commands events handler
@@ -181,5 +184,36 @@ async fn create_slack_events_listener_server() -> Result<(), Box<dyn std::error:
     })
 }
 ``` 
+
+## Options Load URL / `block_suggestion`
+
+When a user types into an `external_select` or `multi_external_select` menu, Slack sends a
+`block_suggestion` payload to the app's *Options Load URL*. Point that URL at the same
+`/interaction` route as the Interactivity Request URL and answer the event with
+`SlackBlockSuggestionResponse`:
+
+```rust,noplaypen
+async fn slack_interaction_events_function(
+    event: SlackInteractionEvent,
+    _client: Arc<SlackHyperClient>,
+    _states: SlackClientEventsUserState,
+) -> Result<SlackInteractionResponse, Box<dyn std::error::Error + Send + Sync>> {
+    match event {
+        SlackInteractionEvent::BlockSuggestion(suggestion_event) => {
+            // `suggestion_event.value` is what the user has typed so far
+            Ok(SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(vec![
+                SlackBlockChoiceItem::new(pt!("Unexpected sentience"), "AI-2323".to_string())
+                    .with_description(pt!("Issue AI-2323")),
+            ]))
+            .into())
+        }
+        _ => Ok(SlackInteractionResponse::Empty),
+    }
+}
+```
+
+Slack limits the reply to 100 options, or to 100 option groups
+(`SlackBlockSuggestionResponse::OptionGroups`) of 100 options each, and only `plain_text`
+is allowed in the option text and description.
 
 Complete example look at [github](https://github.com/abdolence/slack-morphism-rust/tree/master/examples)

--- a/docs/src/socket-mode.md
+++ b/docs/src/socket-mode.md
@@ -12,13 +12,17 @@ and don't want to work with HTTP endpoints yourself.
 ```rust,noplaypen
 use slack_morphism::prelude::*;
 
+// Returning `SlackInteractionResponse` lets one handler answer every kind of
+// interaction: options for `block_suggestion`, a `response_action` for
+// `view_submission`, and a bare acknowledgement for everything else.
+// Handlers returning `Result<(), _>` keep working as before.
 async fn test_interaction_events_function(
     event: SlackInteractionEvent,
     _client: Arc<SlackHyperClient>,
     _states: SlackClientEventsUserState,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<SlackInteractionResponse, Box<dyn std::error::Error + Send + Sync>> {
     println!("{:#?}", event);
-    Ok(())
+    Ok(SlackInteractionResponse::Empty)
 }
 
 async fn test_command_events_function(
@@ -84,6 +88,41 @@ socket_mode_listener.listen_for(&app_token).await?;
 socket_mode_listener.serve().await;
 
 ```
+
+## Options Load URL / `block_suggestion`
+
+Socket Mode apps don't configure an Options Load URL: when a user types into an
+`external_select` or `multi_external_select` menu, the `block_suggestion` payload arrives
+on the same socket as any other interaction. Answer it by returning
+`SlackBlockSuggestionResponse` from the interaction callback:
+
+```rust,noplaypen
+async fn test_interaction_events_function(
+    event: SlackInteractionEvent,
+    _client: Arc<SlackHyperClient>,
+    _states: SlackClientEventsUserState,
+) -> Result<SlackInteractionResponse, Box<dyn std::error::Error + Send + Sync>> {
+    match event {
+        SlackInteractionEvent::BlockSuggestion(suggestion_event) => {
+            // `suggestion_event.value` is what the user has typed so far
+            Ok(SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(vec![
+                SlackBlockChoiceItem::new(pt!("Unexpected sentience"), "AI-2323".to_string())
+                    .with_description(pt!("Issue AI-2323")),
+            ]))
+            .into())
+        }
+        _ => Ok(SlackInteractionResponse::Empty),
+    }
+}
+```
+
+The response travels back in the socket acknowledgement, so it is only sent when Slack
+marked the envelope with `accepts_response_payload`. Otherwise the library logs a warning
+and sends a bare acknowledgement.
+
+Slack limits the reply to 100 options, or to 100 option groups
+(`SlackBlockSuggestionResponse::OptionGroups`) of 100 options each, and only `plain_text`
+is allowed in the option text and description.
 
 ## Important caveats
 

--- a/examples/axum_events_api_server.rs
+++ b/examples/axum_events_api_server.rs
@@ -55,11 +55,45 @@ async fn test_command_event(
     ))
 }
 
+// A tiny in-memory catalogue the external select menus search through.
+const EXAMPLE_ISSUES: &[(&str, &str)] = &[
+    ("AI-2323", "Unexpected sentience"),
+    ("AI-2324", "The model refuses to answer"),
+    ("OPS-101", "Disk pressure on the build host"),
+];
+
+fn find_example_issues(query: &str) -> Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>> {
+    let query = query.to_lowercase();
+    EXAMPLE_ISSUES
+        .iter()
+        .filter(|(id, title)| {
+            id.to_lowercase().contains(&query) || title.to_lowercase().contains(&query)
+        })
+        .map(|(id, title)| {
+            SlackBlockChoiceItem::new(pt!(*title), id.to_string())
+                .with_description(pt!(format!("Issue {}", id)))
+        })
+        .collect()
+}
+
 async fn test_interaction_event(
     Extension(_environment): Extension<Arc<SlackHyperListenerEnvironment>>,
     Extension(event): Extension<SlackInteractionEvent>,
-) {
+) -> SlackInteractionResponse {
     println!("Received interaction event: {:?}", event);
+
+    match event {
+        // Slack posts this to the app's Options Load URL while a user types
+        // into an `external_select` / `multi_external_select` menu.
+        SlackInteractionEvent::BlockSuggestion(suggestion_event) => {
+            SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(
+                find_example_issues(&suggestion_event.value),
+            ))
+            .into()
+        }
+        // Everything else only needs an acknowledgement.
+        _ => SlackInteractionResponse::Empty,
+    }
 }
 
 fn test_error_handler(

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -41,7 +41,7 @@ async fn test_post_message() -> Result<(), Box<dyn std::error::Error + Send + Sy
         SlackApiChatPostMessageRequest::new("#random".into(), message.render_template());
 
     let post_chat_resp = session.chat_post_message(&post_chat_req).await?;
-    println!("post chat resp: {:#?}", &post_chat_resp);
+    println!("post chat resp: {:#?}", post_chat_resp);
 
     Ok(())
 }
@@ -92,7 +92,7 @@ async fn test_file_upload() -> Result<(), Box<dyn std::error::Error + Send + Syn
     let get_upload_url_req =
         SlackApiFilesGetUploadUrlExternalRequest::new("test.txt".into(), test_content.len());
     let upload_url_resp = session.get_upload_url_external(&get_upload_url_req).await?;
-    println!("get url resp: {:#?}", &upload_url_resp);
+    println!("get url resp: {:#?}", upload_url_resp);
 
     let file_upload_req = SlackApiFilesUploadViaUrlRequest::new(
         upload_url_resp.upload_url,
@@ -101,7 +101,7 @@ async fn test_file_upload() -> Result<(), Box<dyn std::error::Error + Send + Syn
     );
 
     let file_upload_resp = session.files_upload_via_url(&file_upload_req).await?;
-    println!("file_upload_resp: {:#?}", &file_upload_resp);
+    println!("file_upload_resp: {:#?}", file_upload_resp);
 
     let complete_file_upload_req =
         SlackApiFilesCompleteUploadExternalRequest::new(vec![SlackApiFilesComplete::new(
@@ -113,7 +113,7 @@ async fn test_file_upload() -> Result<(), Box<dyn std::error::Error + Send + Syn
         .await?;
     println!(
         "complete_file_upload_resp: {:#?}",
-        &complete_file_upload_resp
+        complete_file_upload_resp
     );
 
     let all_channels_scroller = SlackApiConversationsListRequest::new().scroller();

--- a/examples/events_api_server.rs
+++ b/examples/events_api_server.rs
@@ -45,13 +45,47 @@ async fn test_push_events_function(
     Ok(())
 }
 
+// A tiny in-memory catalogue the external select menu below searches through.
+const EXAMPLE_ISSUES: &[(&str, &str)] = &[
+    ("AI-2323", "Unexpected sentience"),
+    ("AI-2324", "The model refuses to answer"),
+    ("OPS-101", "Disk pressure on the build host"),
+];
+
+fn find_example_issues(query: &str) -> Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>> {
+    let query = query.to_lowercase();
+    EXAMPLE_ISSUES
+        .iter()
+        .filter(|(id, title)| {
+            id.to_lowercase().contains(&query) || title.to_lowercase().contains(&query)
+        })
+        .map(|(id, title)| {
+            SlackBlockChoiceItem::new(pt!(*title), id.to_string())
+                .with_description(pt!(format!("Issue {}", id)))
+        })
+        .collect()
+}
+
 async fn test_interaction_events_function(
     event: SlackInteractionEvent,
     _client: Arc<SlackHyperClient>,
     _states: SlackClientEventsUserState,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<SlackInteractionResponse, Box<dyn std::error::Error + Send + Sync>> {
     println!("{:#?}", event);
-    Ok(())
+
+    match event {
+        // Slack posts this to the app's Options Load URL while a user types
+        // into an `external_select` / `multi_external_select` menu.
+        // Answer it with up to 100 plain text options.
+        SlackInteractionEvent::BlockSuggestion(suggestion_event) => Ok(
+            SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(
+                find_example_issues(&suggestion_event.value),
+            ))
+            .into(),
+        ),
+        // Everything else only needs an acknowledgement.
+        _ => Ok(SlackInteractionResponse::Empty),
+    }
 }
 
 async fn test_command_events_function(
@@ -69,7 +103,18 @@ async fn test_command_events_function(
 
     println!("{:#?}", event);
     Ok(SlackCommandEventResponse::new(
-        SlackMessageContent::new().with_text("Working on it".into()),
+        SlackMessageContent::new()
+            .with_text("Working on it".into())
+            .with_blocks(slack_blocks![some_into(
+                SlackSectionBlock::new()
+                    .with_text(md!("Working on it. Anything related?"))
+                    .with_accessory(
+                        SlackBlockExternalSelectElement::new("my-external-select-action".into())
+                            .with_placeholder(pt!("Start typing to search"))
+                            .with_min_query_length(1)
+                            .into()
+                    )
+            )]),
     ))
 }
 

--- a/examples/socket_mode.rs
+++ b/examples/socket_mode.rs
@@ -3,13 +3,46 @@ use slack_morphism::prelude::*;
 use std::sync::Arc;
 use url::Url;
 
+// A tiny in-memory catalogue the external select menu below searches through.
+const EXAMPLE_ISSUES: &[(&str, &str)] = &[
+    ("AI-2323", "Unexpected sentience"),
+    ("AI-2324", "The model refuses to answer"),
+    ("OPS-101", "Disk pressure on the build host"),
+];
+
+fn find_example_issues(query: &str) -> Vec<SlackBlockChoiceItem<SlackBlockPlainTextOnly>> {
+    let query = query.to_lowercase();
+    EXAMPLE_ISSUES
+        .iter()
+        .filter(|(id, title)| {
+            id.to_lowercase().contains(&query) || title.to_lowercase().contains(&query)
+        })
+        .map(|(id, title)| {
+            SlackBlockChoiceItem::new(pt!(*title), id.to_string())
+                .with_description(pt!(format!("Issue {}", id)))
+        })
+        .collect()
+}
+
 async fn test_interaction_events_function(
     event: SlackInteractionEvent,
     _client: Arc<SlackHyperClient>,
     _states: SlackClientEventsUserState,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<SlackInteractionResponse, Box<dyn std::error::Error + Send + Sync>> {
     println!("Interaction event: {:#?}", event);
-    Ok(())
+
+    match event {
+        // Slack sends this while a user types into an `external_select` /
+        // `multi_external_select` menu. Answer it with up to 100 plain text options.
+        SlackInteractionEvent::BlockSuggestion(suggestion_event) => Ok(
+            SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(
+                find_example_issues(&suggestion_event.value),
+            ))
+            .into(),
+        ),
+        // Everything else only needs an acknowledgement.
+        _ => Ok(SlackInteractionResponse::Empty),
+    }
 }
 
 async fn test_command_events_function(
@@ -59,6 +92,11 @@ async fn test_command_events_function(
                         "my-option1-value".to_string()
                     )]
                 )
+            ),
+            some_into(
+                SlackBlockExternalSelectElement::new("my-external-select-action".into())
+                    .with_placeholder(pt!("Start typing to search"))
+                    .with_min_query_length(1)
             )
         ])),
         some_into(

--- a/examples/socket_mode.rs
+++ b/examples/socket_mode.rs
@@ -154,7 +154,7 @@ async fn test_command_events_function(
 
     Ok(SlackCommandEventResponse::new(
         SlackMessageContent::new()
-            .with_text(format!("Working on it: {:?}", user_info_resp.user.team_id).into())
+            .with_text(format!("Working on it: {:?}", user_info_resp.user.team_id))
             .with_blocks(blocks),
     ))
 }
@@ -218,7 +218,7 @@ impl SlackBlocksTemplate for SlackHomeTabBlocksTemplateExample {
             .latest_news
             .clone()
             .into_iter()
-            .map(|news_item| {
+            .flat_map(|news_item| {
                 vec![
                     SlackSectionBlock::new()
                         .with_text(md!(" • *{}*\n>{}", news_item.title, news_item.body))
@@ -234,7 +234,6 @@ impl SlackBlocksTemplate for SlackHomeTabBlocksTemplateExample {
                     .into(),
                 ]
             })
-            .flatten()
             .collect();
 
         [
@@ -254,74 +253,54 @@ impl SlackBlocksTemplate for SlackHomeTabBlocksTemplateExample {
             new_blocks,
             slack_blocks![
                 some_into(SlackDividerBlock::new()),
-                some_into(SlackRichTextBlock::new(
-                    vec![
-                        SlackRichTextSection::new(
-                            vec![
-                                SlackRichTextInlineElement::Text(
-                                    SlackRichTextText::new("Let's use some rich text: ".into())
-                                        .with_style(SlackRichTextStyle::new().with_bold(true))
-                                ),
-                                SlackRichTextInlineElement::Emoji(
-                                    SlackRichTextEmoji::new("slightly_smiling_face".into()).into()
-                                ),
-                            ]
-                            .into()
+                some_into(SlackRichTextBlock::new(vec![
+                    SlackRichTextSection::new(vec![
+                        SlackRichTextInlineElement::Text(
+                            SlackRichTextText::new("Let's use some rich text: ".into())
+                                .with_style(SlackRichTextStyle::new().with_bold(true))
+                        ),
+                        SlackRichTextInlineElement::Emoji(SlackRichTextEmoji::new(
+                            "slightly_smiling_face".into()
+                        )),
+                    ])
+                    .into(),
+                    SlackRichTextSection::new(vec![SlackRichTextInlineElement::Date(
+                        SlackRichTextDate::new(
+                            SlackDateTime::now(),
+                            SlackDateTimeFormats::DateLong.to_string()
                         )
-                        .into(),
-                        SlackRichTextSection::new(
-                            vec![SlackRichTextInlineElement::Date(SlackRichTextDate::new(
-                                SlackDateTime::now(),
-                                SlackDateTimeFormats::DateLong.to_string()
-                            ))]
-                            .into()
-                        )
-                        .into(),
-                        SlackRichTextQuote::new(
-                            vec![
-                                SlackRichTextInlineElement::Text(SlackRichTextText::new(
-                                    "While there is life, there is a hope. ".into()
-                                )),
-                                SlackRichTextInlineElement::Link(SlackRichTextLink::new(
-                                    Url::parse("https://slack-rust.abdolence.dev")
-                                        .expect("A proper url")
-                                        .into()
-                                ))
-                            ]
-                            .into()
-                        )
-                        .into(),
-                        SlackRichTextList::new(
-                            SlackRichTextListStyle::Bullet,
-                            vec![
-                                SlackRichTextSection::new(
-                                    vec![SlackRichTextInlineElement::Text(SlackRichTextText::new(
-                                        "Item 1".into()
-                                    ))]
-                                    .into(),
-                                )
-                                .into(),
-                                SlackRichTextSection::new(
-                                    vec![SlackRichTextInlineElement::Text(SlackRichTextText::new(
-                                        "Item 2".into()
-                                    ))]
-                                    .into(),
-                                )
+                    )])
+                    .into(),
+                    SlackRichTextQuote::new(vec![
+                        SlackRichTextInlineElement::Text(SlackRichTextText::new(
+                            "While there is life, there is a hope. ".into()
+                        )),
+                        SlackRichTextInlineElement::Link(SlackRichTextLink::new(
+                            Url::parse("https://slack-rust.abdolence.dev")
+                                .expect("A proper url")
                                 .into()
-                            ]
-                            .into()
-                        )
-                        .into(),
-                        SlackRichTextPreformatted::new(
-                            vec![SlackRichTextInlineElement::Text(SlackRichTextText::new(
-                                "Let's use some preformatted text: ".into()
-                            ))]
+                        ))
+                    ])
+                    .into(),
+                    SlackRichTextList::new(
+                        SlackRichTextListStyle::Bullet,
+                        vec![
+                            SlackRichTextSection::new(vec![SlackRichTextInlineElement::Text(
+                                SlackRichTextText::new("Item 1".into())
+                            )],)
                             .into(),
-                        )
-                        .into(),
-                    ]
-                    .into()
-                ))
+                            SlackRichTextSection::new(vec![SlackRichTextInlineElement::Text(
+                                SlackRichTextText::new("Item 2".into())
+                            )],)
+                            .into()
+                        ]
+                    )
+                    .into(),
+                    SlackRichTextPreformatted::new(vec![SlackRichTextInlineElement::Text(
+                        SlackRichTextText::new("Let's use some preformatted text: ".into())
+                    )],)
+                    .into(),
+                ]))
             ],
         ]
         .concat()

--- a/src/axum_support/mod.rs
+++ b/src/axum_support/mod.rs
@@ -23,3 +23,5 @@ pub use slack_oauth_routes::*;
 
 mod slack_events_extractors;
 pub use slack_events_extractors::SlackEventsExtractors;
+
+mod slack_events_responses;

--- a/src/axum_support/slack_events_responses.rs
+++ b/src/axum_support/slack_events_responses.rs
@@ -1,0 +1,12 @@
+use crate::events::SlackInteractionResponse;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+impl IntoResponse for SlackInteractionResponse {
+    fn into_response(self) -> Response {
+        match self {
+            SlackInteractionResponse::Empty => StatusCode::OK.into_response(),
+            payload => axum::Json(payload).into_response(),
+        }
+    }
+}

--- a/src/hyper_tokio/listener/interaction_events.rs
+++ b/src/hyper_tokio/listener/interaction_events.rs
@@ -57,55 +57,43 @@ impl<H: 'static + Send + Sync + Connect + Clone> SlackClientEventsHyperListener<
 
                                 let payload = body_params
                                     .get("payload")
-                                    .ok_or_else( || SlackClientError::SystemError(
-                                        SlackClientSystemError::new().with_message(
-                                            "Absent payload in the request from Slack".into(),
-                                        ),
-                                    ))
+                                    .ok_or_else(|| {
+                                        SlackClientError::SystemError(
+                                            SlackClientSystemError::new().with_message(
+                                                "Absent payload in the request from Slack".into(),
+                                            ),
+                                        )
+                                    })
                                     .map_err(|e| e.into());
 
                                 payload.and_then(|payload_value| {
                                     serde_json::from_str::<SlackInteractionEvent>(payload_value)
-                                        .map_err(|e| SlackClientProtocolError::new(e).with_json_body(payload_value.clone()).into())
+                                        .map_err(|e| {
+                                            SlackClientProtocolError::new(e)
+                                                .with_json_body(payload_value.clone())
+                                                .into()
+                                        })
                                 })
                             })
                             .and_then(|event| async move {
                                 match event {
-                                    Ok(view_submission_event@SlackInteractionEvent::ViewSubmission(_)) => {
-                                        match interaction_service_fn(view_submission_event.clone(), sc.clone(), thread_user_state_storage.clone()).await {
-                                            Ok(response) => {
-                                                response.to_http_response(&view_submission_event)
-                                            }
-                                            Err(err) => {
-                                                let status_code = thread_error_handler(err, sc, thread_user_state_storage);
-                                                Response::builder()
-                                                    .status(status_code)
-                                                    .body(Empty::new().boxed())
-                                                    .map_err(|e| e.into())
-                                            }
-                                        }
-
-                                    }
-                                    Ok(block_suggestion_event@SlackInteractionEvent::BlockSuggestion(_)) => {
-                                        match interaction_service_fn(block_suggestion_event.clone(), sc.clone(), thread_user_state_storage.clone()).await {
-                                            Ok(response) => {
-                                                response.to_http_response(&block_suggestion_event)
-                                            }
-                                            Err(err) => {
-                                                let status_code = thread_error_handler(err, sc, thread_user_state_storage);
-                                                Response::builder()
-                                                    .status(status_code)
-                                                    .body(Empty::new().boxed())
-                                                    .map_err(|e| e.into())
-                                            }
-                                        }
-
-                                    }
                                     Ok(interaction_event) => {
-                                        match interaction_service_fn(interaction_event.clone(), sc.clone(), thread_user_state_storage.clone()).await {
-                                            Ok(response) => response.to_http_response(&interaction_event),
+                                        match interaction_service_fn(
+                                            interaction_event.clone(),
+                                            sc.clone(),
+                                            thread_user_state_storage.clone(),
+                                        )
+                                        .await
+                                        {
+                                            Ok(response) => {
+                                                response.to_http_response(&interaction_event)
+                                            }
                                             Err(err) => {
-                                                let status_code = thread_error_handler(err, sc, thread_user_state_storage);
+                                                let status_code = thread_error_handler(
+                                                    err,
+                                                    sc,
+                                                    thread_user_state_storage,
+                                                );
                                                 Response::builder()
                                                     .status(status_code)
                                                     .body(Empty::new().boxed())
@@ -114,7 +102,11 @@ impl<H: 'static + Send + Sync + Connect + Clone> SlackClientEventsHyperListener<
                                         }
                                     }
                                     Err(event_err) => {
-                                        let status_code = thread_error_handler(event_err, sc, thread_user_state_storage);
+                                        let status_code = thread_error_handler(
+                                            event_err,
+                                            sc,
+                                            thread_user_state_storage,
+                                        );
                                         Response::builder()
                                             .status(status_code)
                                             .body(Empty::new().boxed())
@@ -137,17 +129,11 @@ pub trait SlackInteractionEventResponse {
 }
 
 impl SlackInteractionEventResponse for () {
-    fn to_http_response(&self, event: &SlackInteractionEvent) -> AnyStdResult<Response<Body>> {
-        match event {
-            SlackInteractionEvent::ViewSubmission(_) => Response::builder()
-                .status(StatusCode::OK)
-                .body(Empty::new().boxed())
-                .map_err(|e| e.into()),
-            _ => Response::builder()
-                .status(StatusCode::OK)
-                .body(Empty::new().boxed())
-                .map_err(|e| e.into()),
-        }
+    fn to_http_response(&self, _event: &SlackInteractionEvent) -> AnyStdResult<Response<Body>> {
+        Response::builder()
+            .status(StatusCode::OK)
+            .body(Empty::new().boxed())
+            .map_err(|e| e.into())
     }
 }
 
@@ -168,5 +154,72 @@ impl SlackInteractionEventResponse for SlackBlockSuggestionResponse {
             .status(StatusCode::OK)
             .header("content-type", "application/json; charset=utf-8")
             .body(Full::new(json_str.into()).boxed())?)
+    }
+}
+
+impl SlackInteractionEventResponse for SlackInteractionResponse {
+    fn to_http_response(&self, event: &SlackInteractionEvent) -> AnyStdResult<Response<Body>> {
+        match self {
+            SlackInteractionResponse::Empty => ().to_http_response(event),
+            SlackInteractionResponse::ViewSubmission(response) => response.to_http_response(event),
+            SlackInteractionResponse::BlockSuggestion(response) => response.to_http_response(event),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::blocks::SlackBlockChoiceItem;
+    use crate::blocks::SlackBlockPlainTextOnly;
+
+    fn test_block_suggestion_event() -> SlackInteractionEvent {
+        let payload =
+            include_str!("../../models/events/fixtures/interaction_block_suggestion_view.json");
+        serde_json::from_str(payload).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_empty_interaction_response_to_http_response() {
+        let event = test_block_suggestion_event();
+        let response = SlackInteractionResponse::Empty
+            .to_http_response(&event)
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers().get("content-type"), None);
+        assert!(response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_block_suggestion_interaction_response_to_http_response() {
+        let event = test_block_suggestion_event();
+        let response =
+            SlackInteractionResponse::BlockSuggestion(SlackBlockSuggestionResponse::Options(
+                SlackBlockSuggestionOptions::new(vec![SlackBlockChoiceItem::new(
+                    SlackBlockPlainTextOnly::from("Unexpected sentience"),
+                    "AI-2323".to_string(),
+                )]),
+            ))
+            .to_http_response(&event)
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json; charset=utf-8"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap(),
+            r#"{"options":[{"text":{"type":"plain_text","text":"Unexpected sentience"},"value":"AI-2323"}]}"#
+        );
     }
 }

--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -1964,9 +1964,7 @@ mod test {
         assert_eq!(task_card.status, Some(SlackTaskCardStatus::InProgress));
 
         let output = task_card.output.expect("output should be present");
-        let output_block = match output {
-            SlackRichTextInlineContent::RichText(b) => b,
-        };
+        let SlackRichTextInlineContent::RichText(output_block) = output;
         assert_eq!(output_block.elements.len(), 1);
 
         let sources = task_card.sources.expect("sources should be present");

--- a/src/models/blocks/kit.rs
+++ b/src/models/blocks/kit.rs
@@ -385,6 +385,7 @@ pub struct SlackBlockConfirmItem {
 pub struct SlackBlockChoiceItem<T: Into<SlackBlockText>> {
     pub text: T,
     pub value: String,
+    pub description: Option<SlackBlockPlainTextOnly>,
     pub url: Option<Url>,
 }
 

--- a/src/models/events/fixtures/interaction_block_suggestion_message.json
+++ b/src/models/events/fixtures/interaction_block_suggestion_message.json
@@ -1,0 +1,63 @@
+{
+  "type": "block_suggestion",
+  "token": "XXXXXXXXXXXXXXXXXXXXXXXX",
+  "action_id": "my-external-select-action",
+  "block_id": "my-external-select-block",
+  "value": "sentien",
+  "team": {
+    "id": "TXXXXXXXXXX",
+    "domain": "slack-morphism",
+    "enterprise_id": "EXXXXXXXXXX",
+    "enterprise_name": "Slack Morphism Enterprise"
+  },
+  "user": {
+    "id": "UXXXXXXXXXX",
+    "team_id": "TXXXXXXXXXX",
+    "username": "slack.user",
+    "name": "slack.user"
+  },
+  "channel": {
+    "id": "CXXXXXXXXXX",
+    "name": "general"
+  },
+  "container": {
+    "type": "message",
+    "message_ts": "1701735043.989889",
+    "channel_id": "CXXXXXXXXXX",
+    "is_ephemeral": false
+  },
+  "api_app_id": "AXXXXXXXXXX",
+  "enterprise": {
+    "id": "EXXXXXXXXXX",
+    "name": "Slack Morphism Enterprise"
+  },
+  "is_enterprise_install": false,
+  "message": {
+    "type": "message",
+    "subtype": "bot_message",
+    "text": "Pick a related issue",
+    "ts": "1701735043.989889",
+    "bot_id": "BXXXXXXXXXX",
+    "app_id": "AXXXXXXXXXX",
+    "team": "TXXXXXXXXXX",
+    "blocks": [
+      {
+        "type": "section",
+        "block_id": "my-external-select-block",
+        "text": {
+          "type": "mrkdwn",
+          "text": "Pick a related issue"
+        },
+        "accessory": {
+          "type": "external_select",
+          "action_id": "my-external-select-action",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "Start typing to search"
+          },
+          "min_query_length": 1
+        }
+      }
+    ]
+  }
+}

--- a/src/models/events/fixtures/interaction_block_suggestion_view.json
+++ b/src/models/events/fixtures/interaction_block_suggestion_view.json
@@ -1,0 +1,81 @@
+{
+  "type": "block_suggestion",
+  "token": "XXXXXXXXXXXXXXXXXXXXXXXX",
+  "action_id": "my-external-select-action",
+  "block_id": "my-external-select-block",
+  "value": "sentien",
+  "team": {
+    "id": "TXXXXXXXXXX",
+    "domain": "slack-morphism"
+  },
+  "user": {
+    "id": "UXXXXXXXXXX",
+    "team_id": "TXXXXXXXXXX",
+    "username": "slack.user",
+    "name": "slack.user"
+  },
+  "container": {
+    "type": "view",
+    "view_id": "VXXXXXXXXXX"
+  },
+  "api_app_id": "AXXXXXXXXXX",
+  "enterprise": null,
+  "is_enterprise_install": false,
+  "function_data": {
+    "execution_id": "ExXXXXXXXXXX",
+    "function": {
+      "callback_id": "sample_function"
+    },
+    "inputs": {
+      "user_id": "UXXXXXXXXXX"
+    }
+  },
+  "bot_access_token": "xwfp-XXXXXXXXXXXXXXXXXXXXXXXX",
+  "view": {
+    "id": "VXXXXXXXXXX",
+    "team_id": "TXXXXXXXXXX",
+    "type": "modal",
+    "title": {
+      "type": "plain_text",
+      "text": "Report an issue"
+    },
+    "blocks": [
+      {
+        "type": "input",
+        "block_id": "my-external-select-block",
+        "label": {
+          "type": "plain_text",
+          "text": "Related issue"
+        },
+        "element": {
+          "type": "external_select",
+          "action_id": "my-external-select-action",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "Start typing to search"
+          },
+          "min_query_length": 1
+        }
+      }
+    ],
+    "close": {
+      "type": "plain_text",
+      "text": "Cancel"
+    },
+    "submit": {
+      "type": "plain_text",
+      "text": "Submit"
+    },
+    "private_metadata": "",
+    "callback_id": "my-modal-callback-id",
+    "state": {
+      "values": {}
+    },
+    "hash": "1701743154.XXXXXXXX",
+    "root_view_id": "VXXXXXXXXXX",
+    "app_id": "AXXXXXXXXXX",
+    "external_id": "",
+    "app_installed_team_id": "TXXXXXXXXXX",
+    "bot_id": "BXXXXXXXXXX"
+  }
+}

--- a/src/models/events/interaction.rs
+++ b/src/models/events/interaction.rs
@@ -51,6 +51,7 @@ pub struct SlackInteractionBlockSuggestionEvent {
     pub block_id: SlackBlockId,
     pub action_id: SlackActionId,
     pub container: SlackInteractionActionContainer,
+    pub channel: Option<SlackBasicChannelInfo>,
     pub view: Option<SlackView>,
     pub value: String,
     pub message: Option<SlackHistoryMessage>,
@@ -178,4 +179,165 @@ pub struct SlackBlockSuggestionOptions {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackBlockSuggestionOptionGroups {
     pub option_groups: Vec<SlackBlockOptionGroup<SlackBlockPlainTextOnly>>,
+}
+
+/// What an interaction handler hands back to Slack.
+///
+/// A single handler can answer every kind of [`SlackInteractionEvent`] with this:
+/// options for `block_suggestion`, a `response_action` for `view_submission`,
+/// and a plain acknowledgement for everything else.
+///
+/// [`SlackInteractionResponse::Empty`] has no wire representation: transports turn it
+/// into an empty HTTP 200 or a bare Socket Mode acknowledgement, and serialising it
+/// directly is an error rather than a silent `null`.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SlackInteractionResponse {
+    #[serde(skip)]
+    Empty,
+    ViewSubmission(SlackViewSubmissionResponse),
+    BlockSuggestion(SlackBlockSuggestionResponse),
+}
+
+impl From<()> for SlackInteractionResponse {
+    fn from(_: ()) -> Self {
+        SlackInteractionResponse::Empty
+    }
+}
+
+impl From<SlackViewSubmissionResponse> for SlackInteractionResponse {
+    fn from(response: SlackViewSubmissionResponse) -> Self {
+        SlackInteractionResponse::ViewSubmission(response)
+    }
+}
+
+impl From<SlackBlockSuggestionResponse> for SlackInteractionResponse {
+    fn from(response: SlackBlockSuggestionResponse) -> Self {
+        SlackInteractionResponse::BlockSuggestion(response)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_block_suggestion_view_event_deserialization() {
+        let payload = include_str!("./fixtures/interaction_block_suggestion_view.json");
+        let event: SlackInteractionEvent = serde_json::from_str(payload).unwrap();
+
+        match event {
+            SlackInteractionEvent::BlockSuggestion(ev) => {
+                assert_eq!(ev.value, "sentien");
+                assert_eq!(ev.action_id, "my-external-select-action".into());
+                assert_eq!(ev.block_id, "my-external-select-block".into());
+                assert!(matches!(
+                    ev.container,
+                    SlackInteractionActionContainer::View(_)
+                ));
+                assert!(ev.view.is_some());
+                assert_eq!(ev.channel, None);
+                assert_eq!(ev.message, None);
+            }
+            other => panic!("Unexpected interaction event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_block_suggestion_message_event_deserialization() {
+        let payload = include_str!("./fixtures/interaction_block_suggestion_message.json");
+        let event: SlackInteractionEvent = serde_json::from_str(payload).unwrap();
+
+        match event {
+            SlackInteractionEvent::BlockSuggestion(ev) => {
+                assert_eq!(ev.value, "sentien");
+                assert_eq!(ev.action_id, "my-external-select-action".into());
+                assert_eq!(ev.block_id, "my-external-select-block".into());
+                assert!(matches!(
+                    ev.container,
+                    SlackInteractionActionContainer::Message(_)
+                ));
+                assert_eq!(
+                    ev.channel.map(|channel| channel.id),
+                    Some("CXXXXXXXXXX".into())
+                );
+                assert!(ev.message.is_some());
+                assert!(ev.view.is_none());
+            }
+            other => panic!("Unexpected interaction event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_block_suggestion_options_response_serialization() {
+        let response =
+            SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(vec![
+                SlackBlockChoiceItem::new(
+                    SlackBlockPlainTextOnly::from("Unexpected sentience"),
+                    "AI-2323".to_string(),
+                )
+                .with_description(SlackBlockPlainTextOnly::from("Reported by the night shift")),
+            ]));
+
+        assert_eq!(
+            serde_json::to_string(&response).unwrap(),
+            r#"{"options":[{"text":{"type":"plain_text","text":"Unexpected sentience"},"value":"AI-2323","description":{"type":"plain_text","text":"Reported by the night shift"}}]}"#
+        );
+    }
+
+    #[test]
+    fn test_block_suggestion_option_groups_response_serialization() {
+        let response = SlackBlockSuggestionResponse::OptionGroups(
+            SlackBlockSuggestionOptionGroups::new(vec![SlackBlockOptionGroup::new(
+                SlackBlockPlainTextOnly::from("Open"),
+                vec![SlackBlockChoiceItem::new(
+                    SlackBlockPlainTextOnly::from("Unexpected sentience"),
+                    "AI-2323".to_string(),
+                )],
+            )]),
+        );
+
+        assert_eq!(
+            serde_json::to_string(&response).unwrap(),
+            r#"{"option_groups":[{"label":{"type":"plain_text","text":"Open"},"options":[{"text":{"type":"plain_text","text":"Unexpected sentience"},"value":"AI-2323"}]}]}"#
+        );
+    }
+
+    #[test]
+    fn test_interaction_response_from_unit_is_empty() {
+        assert_eq!(
+            SlackInteractionResponse::from(()),
+            SlackInteractionResponse::Empty
+        );
+    }
+
+    #[test]
+    fn test_interaction_response_empty_is_not_serializable() {
+        assert!(serde_json::to_string(&SlackInteractionResponse::Empty).is_err());
+    }
+
+    #[test]
+    fn test_interaction_response_block_suggestion_serialization() {
+        let inner = SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(vec![
+            SlackBlockChoiceItem::new(
+                SlackBlockPlainTextOnly::from("Unexpected sentience"),
+                "AI-2323".to_string(),
+            ),
+        ]));
+
+        assert_eq!(
+            serde_json::to_string(&SlackInteractionResponse::from(inner.clone())).unwrap(),
+            serde_json::to_string(&inner).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_interaction_response_view_submission_serialization() {
+        let inner = SlackViewSubmissionResponse::Clear(SlackViewSubmissionClearResponse::new());
+
+        assert_eq!(
+            serde_json::to_string(&SlackInteractionResponse::from(inner)).unwrap(),
+            r#"{"response_action":"clear"}"#
+        );
+    }
 }

--- a/src/models/socket_mode/mod.rs
+++ b/src/models/socket_mode/mod.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
 use crate::events::{
-    SlackCommandEvent, SlackCommandEventResponse, SlackInteractionEvent, SlackPushEventCallback,
+    SlackCommandEvent, SlackCommandEventResponse, SlackInteractionEvent, SlackInteractionResponse,
+    SlackPushEventCallback,
 };
 use crate::*;
 use rvstruct::*;
@@ -100,4 +101,80 @@ pub struct SlackSocketModeCommandEventAck {
     #[serde(flatten)]
     pub envelope_ack_params: SlackSocketModeEventCommonAcknowledge,
     pub payload: Option<SlackCommandEventResponse>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
+pub struct SlackSocketModeInteractiveEventAck {
+    #[serde(flatten)]
+    pub envelope_ack_params: SlackSocketModeEventCommonAcknowledge,
+    pub payload: Option<SlackInteractionResponse>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::blocks::{SlackBlockChoiceItem, SlackBlockPlainTextOnly};
+    use crate::events::{
+        SlackBlockSuggestionOptions, SlackBlockSuggestionResponse, SlackInteractionResponse,
+    };
+
+    #[test]
+    fn test_socket_mode_interactive_block_suggestion_event_deserialization() {
+        let payload = format!(
+            r#"{{"type":"interactive","envelope_id":"57d6a792-4d35-4d0b-b6aa-3361493e1caf","accepts_response_payload":true,"payload":{}}}"#,
+            include_str!("../events/fixtures/interaction_block_suggestion_view.json")
+        );
+
+        let event: SlackSocketModeEvent = serde_json::from_str(&payload).unwrap();
+
+        match event {
+            SlackSocketModeEvent::Interactive(interactive) => {
+                assert_eq!(
+                    interactive.envelope_params.envelope_id,
+                    SlackSocketModeEnvelopeId("57d6a792-4d35-4d0b-b6aa-3361493e1caf".into())
+                );
+                assert!(interactive.envelope_params.accepts_response_payload);
+                assert!(matches!(
+                    interactive.payload,
+                    SlackInteractionEvent::BlockSuggestion(_)
+                ));
+            }
+            other => panic!("Unexpected socket mode event: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_socket_mode_interactive_ack_with_payload_serialization() {
+        let ack =
+            SlackSocketModeInteractiveEventAck::new(SlackSocketModeEventCommonAcknowledge::new(
+                SlackSocketModeEnvelopeId("57d6a792-4d35-4d0b-b6aa-3361493e1caf".into()),
+            ))
+            .with_payload(SlackInteractionResponse::BlockSuggestion(
+                SlackBlockSuggestionResponse::Options(SlackBlockSuggestionOptions::new(vec![
+                    SlackBlockChoiceItem::new(
+                        SlackBlockPlainTextOnly::from("Unexpected sentience"),
+                        "AI-2323".to_string(),
+                    ),
+                ])),
+            ));
+
+        assert_eq!(
+            serde_json::to_string(&ack).unwrap(),
+            r#"{"envelope_id":"57d6a792-4d35-4d0b-b6aa-3361493e1caf","payload":{"options":[{"text":{"type":"plain_text","text":"Unexpected sentience"},"value":"AI-2323"}]}}"#
+        );
+    }
+
+    #[test]
+    fn test_socket_mode_interactive_ack_without_payload_serialization() {
+        let ack =
+            SlackSocketModeInteractiveEventAck::new(SlackSocketModeEventCommonAcknowledge::new(
+                SlackSocketModeEnvelopeId("57d6a792-4d35-4d0b-b6aa-3361493e1caf".into()),
+            ));
+
+        assert_eq!(
+            serde_json::to_string(&ack).unwrap(),
+            r#"{"envelope_id":"57d6a792-4d35-4d0b-b6aa-3361493e1caf"}"#
+        );
+    }
 }

--- a/src/socket_mode/callbacks.rs
+++ b/src/socket_mode/callbacks.rs
@@ -57,8 +57,11 @@ where
             + Sync,
     >,
     pub interaction_callback: Box<
-        dyn SlackSocketModeListenerCallback<SCHC, SlackInteractionEvent, UserCallbackResult<()>>
-            + Send
+        dyn SlackSocketModeListenerCallback<
+                SCHC,
+                SlackInteractionEvent,
+                UserCallbackResult<SlackInteractionResponse>,
+            > + Send
             + Sync,
     >,
     pub push_events_callback: Box<
@@ -123,14 +126,27 @@ where
         )))
     }
 
-    pub fn with_interaction_events<F>(
+    /// Registers an interaction events callback.
+    ///
+    /// The callback may return anything convertible into [`SlackInteractionResponse`],
+    /// so both the existing `Result<(), _>` handlers and handlers replying with
+    /// options for `block_suggestion` or a `response_action` for `view_submission` work here.
+    pub fn with_interaction_events<F, R>(
         mut self,
         interaction_events_fn: UserCallbackFunction<SlackInteractionEvent, F, SCHC>,
     ) -> Self
     where
-        F: Future<Output = UserCallbackResult<()>> + Send + 'static,
+        F: Future<Output = UserCallbackResult<R>> + Send + 'static,
+        R: Into<SlackInteractionResponse> + Send + 'static,
     {
-        self.interaction_callback = Box::new(interaction_events_fn);
+        self.interaction_callback = Box::new(
+            move |event: SlackInteractionEvent,
+                  client: Arc<SlackClient<SCHC>>,
+                  states: SlackClientEventsUserState| {
+                let user_callback = interaction_events_fn(event, client, states);
+                async move { user_callback.await.map(Into::into) }
+            },
+        );
         self
     }
 
@@ -138,7 +154,7 @@ where
         event: SlackInteractionEvent,
         _client: Arc<SlackClient<SCHC>>,
         _states: SlackClientEventsUserState,
-    ) -> UserCallbackResult<()> {
+    ) -> UserCallbackResult<SlackInteractionResponse> {
         warn!(
             "No callback is specified for interactive events: {:?}",
             event

--- a/src/socket_mode/clients_manager_listener.rs
+++ b/src/socket_mode/clients_manager_listener.rs
@@ -5,8 +5,10 @@ use async_trait::async_trait;
 use std::sync::{Arc, Weak};
 
 use crate::errors::*;
+use crate::events::SlackInteractionResponse;
 use crate::listener::SlackClientEventsListenerEnvironment;
 use crate::socket_mode::wss_client_id::SlackSocketModeWssClientId;
+use rvstruct::ValueStruct;
 use tracing::*;
 
 #[async_trait]
@@ -90,11 +92,13 @@ where
                         None
                     }
                     SlackSocketModeEvent::Interactive(event) => {
-                        let reply =
-                            serde_json::to_string(&SlackSocketModeEventCommonAcknowledge::new(
-                                event.envelope_params.envelope_id,
-                            ))
-                            .unwrap();
+                        let envelope_id = event.envelope_params.envelope_id.clone();
+                        let accepts_response_payload =
+                            event.envelope_params.accepts_response_payload;
+                        let reply = serde_json::to_string(
+                            &SlackSocketModeEventCommonAcknowledge::new(envelope_id.clone()),
+                        )
+                        .unwrap();
 
                         match self
                             .callbacks
@@ -106,7 +110,34 @@ where
                             )
                             .await
                         {
-                            Ok(_) => Some(reply),
+                            Ok(SlackInteractionResponse::Empty) => Some(reply),
+                            Ok(payload) if accepts_response_payload => Some(
+                                serde_json::to_string(
+                                    &SlackSocketModeInteractiveEventAck::new(
+                                        SlackSocketModeEventCommonAcknowledge::new(envelope_id),
+                                    )
+                                    .with_payload(payload),
+                                )
+                                .unwrap(),
+                            ),
+                            Ok(payload) => {
+                                let response_kind = match payload {
+                                    SlackInteractionResponse::Empty => "empty",
+                                    SlackInteractionResponse::ViewSubmission(_) => {
+                                        "view_submission"
+                                    }
+                                    SlackInteractionResponse::BlockSuggestion(_) => {
+                                        "block_suggestion"
+                                    }
+                                };
+                                warn!(
+                                    "[{}] Dropping a '{}' interaction response for the envelope '{}': Slack didn't accept a response payload for it",
+                                    client_id.to_string(),
+                                    response_kind,
+                                    envelope_id.value()
+                                );
+                                Some(reply)
+                            }
                             Err(err) => {
                                 if self.listener_environment.error_handler.clone()(
                                     err,

--- a/src/socket_mode/clients_manager_listener.rs
+++ b/src/socket_mode/clients_manager_listener.rs
@@ -9,6 +9,7 @@ use crate::events::SlackInteractionResponse;
 use crate::listener::SlackClientEventsListenerEnvironment;
 use crate::socket_mode::wss_client_id::SlackSocketModeWssClientId;
 use rvstruct::ValueStruct;
+use serde::Serialize;
 use tracing::*;
 
 #[async_trait]
@@ -46,6 +47,25 @@ where
             clients_manager: manager,
             listener_environment,
             callbacks: Arc::new(callbacks),
+        }
+    }
+
+    /// Serialises a Socket Mode acknowledgement frame.
+    ///
+    /// A failure is reported to the configured error handler and yields `None`, so no
+    /// acknowledgement is sent and Slack redelivers the envelope instead of the client
+    /// panicking.
+    fn ack_frame<A: Serialize>(&self, ack: &A) -> Option<String> {
+        match serde_json::to_string(ack) {
+            Ok(frame) => Some(frame),
+            Err(err) => {
+                self.listener_environment.error_handler.clone()(
+                    SlackClientProtocolError::new(err).into(),
+                    self.listener_environment.client.clone(),
+                    self.listener_environment.user_state.clone(),
+                );
+                None
+            }
         }
     }
 }
@@ -95,10 +115,11 @@ where
                         let envelope_id = event.envelope_params.envelope_id.clone();
                         let accepts_response_payload =
                             event.envelope_params.accepts_response_payload;
-                        let reply = serde_json::to_string(
-                            &SlackSocketModeEventCommonAcknowledge::new(envelope_id.clone()),
-                        )
-                        .unwrap();
+                        let bare_ack = || {
+                            self.ack_frame(&SlackSocketModeEventCommonAcknowledge::new(
+                                envelope_id.clone(),
+                            ))
+                        };
 
                         match self
                             .callbacks
@@ -110,15 +131,12 @@ where
                             )
                             .await
                         {
-                            Ok(SlackInteractionResponse::Empty) => Some(reply),
-                            Ok(payload) if accepts_response_payload => Some(
-                                serde_json::to_string(
-                                    &SlackSocketModeInteractiveEventAck::new(
-                                        SlackSocketModeEventCommonAcknowledge::new(envelope_id),
-                                    )
-                                    .with_payload(payload),
+                            Ok(SlackInteractionResponse::Empty) => bare_ack(),
+                            Ok(payload) if accepts_response_payload => self.ack_frame(
+                                &SlackSocketModeInteractiveEventAck::new(
+                                    SlackSocketModeEventCommonAcknowledge::new(envelope_id.clone()),
                                 )
-                                .unwrap(),
+                                .with_payload(payload),
                             ),
                             Ok(payload) => {
                                 let response_kind = match payload {
@@ -136,7 +154,7 @@ where
                                     response_kind,
                                     envelope_id.value()
                                 );
-                                Some(reply)
+                                bare_ack()
                             }
                             Err(err) => {
                                 if self.listener_environment.error_handler.clone()(
@@ -146,7 +164,7 @@ where
                                 )
                                 .is_success()
                                 {
-                                    Some(reply)
+                                    bare_ack()
                                 } else {
                                     None
                                 }
@@ -154,11 +172,11 @@ where
                         }
                     }
                     SlackSocketModeEvent::EventsApi(event) => {
-                        let reply =
-                            serde_json::to_string(&SlackSocketModeEventCommonAcknowledge::new(
-                                event.envelope_params.envelope_id,
+                        let bare_ack = || {
+                            self.ack_frame(&SlackSocketModeEventCommonAcknowledge::new(
+                                event.envelope_params.envelope_id.clone(),
                             ))
-                            .unwrap();
+                        };
 
                         match self
                             .callbacks
@@ -170,7 +188,7 @@ where
                             )
                             .await
                         {
-                            Ok(_) => Some(reply),
+                            Ok(_) => bare_ack(),
                             Err(err) => {
                                 if self.listener_environment.error_handler.clone()(
                                     err,
@@ -179,7 +197,7 @@ where
                                 )
                                 .is_success()
                                 {
-                                    Some(reply)
+                                    bare_ack()
                                 } else {
                                     None
                                 }
@@ -198,16 +216,13 @@ where
                             )
                             .await
                         {
-                            Ok(reply) => Some(
-                                serde_json::to_string(
-                                    &SlackSocketModeCommandEventAck::new(
-                                        SlackSocketModeEventCommonAcknowledge::new(
-                                            event.envelope_params.envelope_id,
-                                        ),
-                                    )
-                                    .with_payload(reply),
+                            Ok(reply) => self.ack_frame(
+                                &SlackSocketModeCommandEventAck::new(
+                                    SlackSocketModeEventCommonAcknowledge::new(
+                                        event.envelope_params.envelope_id,
+                                    ),
                                 )
-                                .unwrap(),
+                                .with_payload(reply),
                             ),
                             Err(err) => {
                                 if self.listener_environment.error_handler.clone()(
@@ -217,16 +232,11 @@ where
                                 )
                                 .is_success()
                                 {
-                                    Some(
-                                        serde_json::to_string(
-                                            &SlackSocketModeCommandEventAck::new(
-                                                SlackSocketModeEventCommonAcknowledge::new(
-                                                    event.envelope_params.envelope_id,
-                                                ),
-                                            ),
-                                        )
-                                        .unwrap(),
-                                    )
+                                    self.ack_frame(&SlackSocketModeCommandEventAck::new(
+                                        SlackSocketModeEventCommonAcknowledge::new(
+                                            event.envelope_params.envelope_id,
+                                        ),
+                                    ))
                                 } else {
                                     None
                                 }


### PR DESCRIPTION
Adds SlackInteractionResponse so a single interaction handler can answer block_suggestion with options, view_submission with a response_action, and everything else with a plain acknowledgement, over hyper, axum and Socket Mode. Socket Mode now sends the handler's payload in the envelope ack when accepts_response_payload is set; block_suggestion gains the channel field and options gain description. Refs #254 (the payload types themselves shipped in #290; this closes the remaining gaps with fixtures, tests, examples and docs).