### PR TITLE
fix: Publish the converter module dropped by wasm-pack's .gitignore

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Build converter
         run: wasm-pack build tools/blockkit-to-rust --release --target web --no-typescript --no-pack --out-dir ../../docs/src/blockkit --out-name blockkit_to_rust
       - run: cd docs && mdbook build
+      # wasm-pack writes a `.gitignore` containing `*` into its out-dir and mdbook
+      # copies it into the output; the publish action adds files with git, so
+      # that file would silently drop the module from the site.
+      - name: Unignore the converter module
+        run: rm -f docs/output/blockkit/.gitignore
       - name: Copy CNAME
         run: cp CNAME docs/output
       - name: Deploy


### PR DESCRIPTION
The first deploy after #385 published the Block Kit page with the widget assets but no blockkit/ directory: wasm-pack writes a .gitignore containing * into its out-dir, mdbook copies it into docs/output, and actions-gh-pages adds files through git, so the module and its glue were skipped. Remove that file from the output before publishing.