### PR TITLE
fix: Do not expose request signatures in verifier errors

### DIFF
--- a/src/signature_verifier.rs
+++ b/src/signature_verifier.rs
@@ -52,7 +52,7 @@ impl SlackEventSignatureVerifier {
                 SlackEventWrongSignatureErrorInit {
                     body_len: body.len(),
                     ts: ts.into(),
-                    received_hash: hash.into(),
+                    received_hash_prefix: hash.chars().take(11).collect(),
                 }
                 .into(),
             ))
@@ -181,20 +181,23 @@ impl Error for SlackEventAbsentSignatureError {}
 /// The expected signature for the request is deliberately not carried by this
 /// error: any `Debug`/`Display` of it (as a default listener error handler
 /// does) would hand out a valid signature for the same request body and
-/// timestamp.
+/// timestamp. The received signature is kept only as a short prefix for the
+/// same reason: when the local signing secret is misconfigured, the request
+/// Slack sent is correctly signed, so the full received value is itself a
+/// valid credential for this body and timestamp and must not reach the logs.
 #[derive(Debug, PartialEq, Eq, Clone, Builder)]
 pub struct SlackEventWrongSignatureError {
     pub body_len: usize,
     pub ts: String,
-    pub received_hash: String,
+    pub received_hash_prefix: String,
 }
 
 impl Display for SlackEventWrongSignatureError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Slack API signature validation error: Body len: {}, received ts: {}, received hash: {}",
-            self.body_len, self.ts, self.received_hash
+            "Slack API signature validation error: Body len: {}, received ts: {}, received hash prefix: {}...",
+            self.body_len, self.ts, self.received_hash_prefix
         )
     }
 }
@@ -320,6 +323,38 @@ mod test {
         assert!(!format!("{:?}", inner).contains(&correct_hash));
         assert!(!format!("{}", err).contains(&correct_hash));
         assert!(!format!("{:?}", err).contains(&correct_hash));
+    }
+
+    #[test]
+    fn wrong_signature_error_does_not_reveal_received_signature() {
+        use sha2::Digest;
+
+        let key_str_correct: String = hex::encode(Sha256::digest("correct-key"));
+        let key_str_malicious: String = hex::encode(Sha256::digest("malicious-key"));
+
+        let verifier_correct = SlackEventSignatureVerifier::new(&key_str_correct.into());
+        let verifier_malicious = SlackEventSignatureVerifier::new(&key_str_malicious.into());
+
+        const TEST_BODY: &str = "test-body";
+        let test_ts = current_unix_seconds().to_string();
+
+        let received_hash = verifier_malicious.sign(TEST_BODY, &test_ts).unwrap();
+        let err = verifier_correct
+            .verify(&received_hash, TEST_BODY, &test_ts)
+            .unwrap_err();
+
+        let inner = match &err {
+            SlackEventSignatureVerifierError::WrongSignatureError(inner) => inner,
+            other => panic!("unexpected error, {}", other),
+        };
+
+        let expected_prefix: String = received_hash.chars().take(11).collect();
+
+        assert!(!format!("{}", inner).contains(&received_hash));
+        assert!(!format!("{:?}", inner).contains(&received_hash));
+        assert!(!format!("{}", err).contains(&received_hash));
+        assert!(!format!("{:?}", err).contains(&received_hash));
+        assert!(format!("{}", inner).contains(&expected_prefix));
     }
 
     #[test]

--- a/src/signature_verifier.rs
+++ b/src/signature_verifier.rs
@@ -53,7 +53,6 @@ impl SlackEventSignatureVerifier {
                     body_len: body.len(),
                     ts: ts.into(),
                     received_hash: hash.into(),
-                    generated_hash: hash_to_check,
                 }
                 .into(),
             ))
@@ -179,23 +178,23 @@ impl Display for SlackEventAbsentSignatureError {
 
 impl Error for SlackEventAbsentSignatureError {}
 
+/// The expected signature for the request is deliberately not carried by this
+/// error: any `Debug`/`Display` of it (as a default listener error handler
+/// does) would hand out a valid signature for the same request body and
+/// timestamp.
 #[derive(Debug, PartialEq, Eq, Clone, Builder)]
 pub struct SlackEventWrongSignatureError {
     pub body_len: usize,
     pub ts: String,
     pub received_hash: String,
-    pub generated_hash: String,
 }
 
 impl Display for SlackEventWrongSignatureError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Slack API signature validation error: Body len: {}, received ts: {}, received hash: {}, generated hash: {}",
-            self.body_len,
-            self.ts,
-            self.received_hash,
-            self.generated_hash
+            "Slack API signature validation error: Body len: {}, received ts: {}, received hash: {}",
+            self.body_len, self.ts, self.received_hash
         )
     }
 }
@@ -293,6 +292,34 @@ mod test {
             SlackEventSignatureVerifierError::WrongSignatureError(_) => {}
             _ => panic!("unexpected error, {}", err),
         }
+    }
+
+    #[test]
+    fn wrong_signature_error_does_not_reveal_expected_signature() {
+        use sha2::Digest;
+
+        let key_str: String = hex::encode(Sha256::digest("test-key"));
+        let verifier = SlackEventSignatureVerifier::new(&key_str.into());
+
+        const TEST_BODY: &str = "test-body";
+        let test_ts = current_unix_seconds().to_string();
+
+        let correct_hash = verifier.sign(TEST_BODY, &test_ts).unwrap();
+        let wrong_hash = "v0=0000000000000000000000000000000000000000000000000000000000000000";
+
+        let err = verifier
+            .verify(wrong_hash, TEST_BODY, &test_ts)
+            .unwrap_err();
+
+        let inner = match &err {
+            SlackEventSignatureVerifierError::WrongSignatureError(inner) => inner,
+            other => panic!("unexpected error, {}", other),
+        };
+
+        assert!(!format!("{}", inner).contains(&correct_hash));
+        assert!(!format!("{:?}", inner).contains(&correct_hash));
+        assert!(!format!("{}", err).contains(&correct_hash));
+        assert!(!format!("{:?}", err).contains(&correct_hash));
     }
 
     #[test]


### PR DESCRIPTION
SlackEventWrongSignatureError carried the correct HMAC for the rejected request, and its Debug and Display output reached the default listener error logger, so anyone able to read the logs could replay the request with a valid signature. The expected signature is no longer stored in the error at all, and the received signature is kept only as a short prefix, since a correctly signed Slack request against a misconfigured local secret would otherwise put a valid credential into the logs too. Regression tests pin both properties.